### PR TITLE
[back-762] add Item to CollectionStory graph

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -2,11 +2,3 @@ type Query {
   getCollections(page: Int, perPage: Int): CollectionsResult
   getCollection(slug: String!): Collection
 }
-
-extend type Item @key(fields: "givenUrl") {
-    "key field to identify the Item entity in the Parser service"
-    givenUrl: Url! @external
-
-    "If the item is a collection allow them to get the collection information"
-    collection: Collection
-}

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -17,6 +17,14 @@ directive @cacheControl(
   scope: CacheControlScope
 ) on FIELD_DEFINITION | OBJECT | INTERFACE
 
+extend type Item @key(fields: "givenUrl") {
+  "key field to identify the Item entity in the Parser service"
+  givenUrl: Url! @external
+
+  "If the item is a collection allow them to get the collection information"
+  collection: Collection
+}
+
 type Collection {
   externalId: ID!
   slug: String!
@@ -45,7 +53,7 @@ type CollectionAuthor {
   active: Boolean
 }
 
-type CollectionStory {
+type CollectionStory @key(fields: "item { givenUrl }") {
   externalId: ID!
   url: Url!
   title: String!
@@ -54,8 +62,8 @@ type CollectionStory {
   authors: [CollectionStoryAuthor]
   publisher: String
   sortOrder: Int
+  item: Item
 }
-
 
 type CollectionStoryAuthor {
   name: String!

--- a/src/admin/server.ts
+++ b/src/admin/server.ts
@@ -1,12 +1,19 @@
 import { ApolloServer } from 'apollo-server-express';
+import { buildFederatedSchema } from '@apollo/federation';
 import { typeDefsAdmin } from '../typeDefs';
 import { resolvers as adminResolvers } from './resolvers';
 import { sentryPlugin } from '@pocket-tools/apollo-utils';
 import { client } from '../database/client';
 
 export const server = new ApolloServer({
-  typeDefs: typeDefsAdmin,
-  resolvers: adminResolvers,
+  // NOTE! this server is *not* part of the federated schema
+  // the only reason we are calling `buildFederatedSchema` here is because
+  // our shared schema file incorporates federation-related syntax,
+  // and ApolloServer will fail on that *unless* we build the schema
+  // as federated.
+  schema: buildFederatedSchema([
+    { typeDefs: typeDefsAdmin, resolvers: adminResolvers },
+  ]),
   plugins: [sentryPlugin],
   context: {
     db: client(),

--- a/src/database/client.ts
+++ b/src/database/client.ts
@@ -1,5 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 
+import { collectionStoryInjectItemMiddleware } from '../middleware/prisma';
+
 let prisma;
 
 export function client(): PrismaClient {
@@ -8,6 +10,11 @@ export function client(): PrismaClient {
   prisma = new PrismaClient({
     // log: ['query', 'info', `warn`, `error`],
   });
+
+  // this is a middleware function that injects non-database / non-prisma
+  // data into each CollectionStory. this extra data is necessary to relate
+  // a CollectionStory with a parser Item.
+  prisma.$use(collectionStoryInjectItemMiddleware);
 
   return prisma;
 }

--- a/src/middleware/prisma.spec.ts
+++ b/src/middleware/prisma.spec.ts
@@ -1,0 +1,215 @@
+import { MiddlewareParams } from 'prisma';
+
+import * as PrismaMiddleware from './prisma';
+
+describe('prisma middleware', () => {
+  const collection1: PrismaMiddleware.CollectionWithStories = {
+    id: 1,
+    externalId: 'abc-123',
+    slug: 'all-about-bowling',
+    title: 'All About Bowling',
+    excerpt: 'test',
+    intro: 'test',
+    imageUrl: 'test',
+    status: 'draft',
+    publishedAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    stories: [
+      {
+        id: 1,
+        externalId: 'xyz-123',
+        collectionId: 1,
+        url: 'test.com/bowling',
+        title: 'test',
+        excerpt: 'test',
+        imageUrl: 'test',
+        authors: 'test',
+        publisher: 'test',
+        sortOrder: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: 2,
+        externalId: 'xyz-125',
+        collectionId: 1,
+        url: 'https://thedude.com/walter/calm',
+        title: 'test',
+        excerpt: 'test',
+        imageUrl: 'test',
+        authors: 'test',
+        publisher: 'test',
+        sortOrder: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ],
+  };
+
+  const collection2: PrismaMiddleware.CollectionWithStories = {
+    id: 1,
+    externalId: 'abc-123',
+    slug: 'all-about-bowling',
+    title: 'All About Bowling',
+    excerpt: 'test',
+    intro: 'test',
+    imageUrl: 'test',
+    status: 'draft',
+    publishedAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    stories: [
+      {
+        id: 1,
+        externalId: 'xyz-123',
+        collectionId: 1,
+        url: 'test.com/bowling',
+        title: 'test',
+        excerpt: 'test',
+        imageUrl: 'test',
+        authors: 'test',
+        publisher: 'test',
+        sortOrder: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: 2,
+        externalId: 'xyz-125',
+        collectionId: 1,
+        url: 'https://thedude.com/walter/calm',
+        title: 'test',
+        excerpt: 'test',
+        imageUrl: 'test',
+        authors: 'test',
+        publisher: 'test',
+        sortOrder: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ],
+  };
+
+  describe('injectItemIntoCollectionStories', () => {
+    it('should inject an item property for each story', () => {
+      const res: PrismaMiddleware.CollectionWithStoriesWithItem = PrismaMiddleware.injectItemIntoCollectionStories(
+        collection1
+      );
+
+      expect(res.stories[0].item.givenUrl).toEqual('test.com/bowling');
+      expect(res.stories[1].item.givenUrl).toEqual(
+        'https://thedude.com/walter/calm'
+      );
+    });
+  });
+
+  describe('collectionStoryInjectItemMiddleware', () => {
+    let params: MiddlewareParams;
+    let injectItemSpy;
+
+    const nextSingle = async function (params: MiddlewareParams) {
+      return await collection1;
+    };
+
+    const nextMany = async function (params: MiddlewareParams) {
+      return await [collection1, collection2];
+    };
+
+    beforeEach(() => {
+      // reset the params object
+      params = {
+        model: 'Collection',
+        args: 'foo',
+        dataPath: ['test'],
+        runInTransaction: false,
+      };
+
+      // spy on inject function
+      injectItemSpy = jest.spyOn(
+        PrismaMiddleware,
+        'injectItemIntoCollectionStories'
+      );
+    });
+
+    afterEach(() => {
+      // restore the spy
+      injectItemSpy.mockRestore();
+    });
+
+    it('should apply middleware for a Collection query of findUnique', async () => {
+      params.action = 'findUnique';
+
+      await PrismaMiddleware.collectionStoryInjectItemMiddleware(
+        params,
+        nextSingle
+      );
+
+      expect(injectItemSpy).toBeCalledTimes(1);
+    });
+
+    it('should apply middleware for a Collection query of findFirst', async () => {
+      params.action = 'findFirst';
+
+      await PrismaMiddleware.collectionStoryInjectItemMiddleware(
+        params,
+        nextSingle
+      );
+
+      expect(injectItemSpy).toBeCalledTimes(1);
+    });
+
+    it('should apply middleware for a Collection query of findMany', async () => {
+      params.action = 'findMany';
+
+      await PrismaMiddleware.collectionStoryInjectItemMiddleware(
+        params,
+        nextMany
+      );
+
+      // nextMany returns two collections in an array, so the inject function
+      // should have been called twice
+      expect(injectItemSpy).toBeCalledTimes(2);
+    });
+
+    it('should not apply middleware when a Collection is updated', async () => {
+      params.action = 'update';
+
+      await PrismaMiddleware.collectionStoryInjectItemMiddleware(
+        params,
+        nextSingle
+      );
+
+      // nextMany returns two collections in an array, so the inject function
+      // should have been called twice
+      expect(injectItemSpy).toBeCalledTimes(0);
+    });
+
+    it('should not apply middleware when a Collection is created', async () => {
+      params.action = 'update';
+
+      await PrismaMiddleware.collectionStoryInjectItemMiddleware(
+        params,
+        nextSingle
+      );
+
+      // nextMany returns two collections in an array, so the inject function
+      // should have been called twice
+      expect(injectItemSpy).toBeCalledTimes(0);
+    });
+
+    it('should not apply middleware on a non-Collection object', async () => {
+      params.model = 'CollectionStory';
+      params.action = 'findFirst';
+
+      await PrismaMiddleware.collectionStoryInjectItemMiddleware(
+        params,
+        nextSingle
+      );
+
+      // nextMany returns two collections in an array, so the inject function
+      // should have been called twice
+      expect(injectItemSpy).toBeCalledTimes(0);
+    });
+  });
+});

--- a/src/middleware/prisma.ts
+++ b/src/middleware/prisma.ts
@@ -1,0 +1,84 @@
+import { Collection, CollectionStory } from '@prisma/client';
+import { MiddlewareParams } from 'prisma';
+
+// THIS IS WEIRD!
+// we are importing every export *in this file* into itself so we can spy
+// on nested function calls - see below for more info
+import * as PrismaMiddleware from './prisma';
+
+// this type prepares a CollectionStory to have an extra 'item' property
+type CollectionStoryWithItem = CollectionStory & {
+  item: {
+    // the name of this property *must* be `givenUrl`. this is the name of the
+    // field on the Parser Item model that is used to retrieve a Parser Item.
+    // all we're doing is duplicating the CollectionStory `url` property here.
+    givenUrl: string;
+  };
+};
+
+// prisma types don't include associations - this is just to have type safety
+// in our function param below.
+export type CollectionWithStories = Collection & {
+  stories: CollectionStory[];
+};
+
+// this is simply to define a return type on the function below.
+export type CollectionWithStoriesWithItem = Collection & {
+  stories: CollectionStoryWithItem[];
+};
+
+export function injectItemIntoCollectionStories(
+  collection: CollectionWithStories
+): CollectionWithStoriesWithItem {
+  // map over each CollectionStory, injecting a new `item` property that
+  // is a copy of the data in the `url` property.
+  const stories = collection.stories.map((story) => {
+    return {
+      ...story,
+      item: {
+        givenUrl: story.url,
+      },
+    };
+  });
+
+  // build a new object to conform to the return type
+  return {
+    ...collection,
+    stories,
+  };
+}
+
+// conforms to the prisma middleware API
+// https://www.prisma.io/docs/reference/api-reference/prisma-client-reference/#use
+export async function collectionStoryInjectItemMiddleware(
+  params: MiddlewareParams,
+  next
+): Promise<any> {
+  // let all other middlewares finish first
+  let results = await next(params);
+
+  // we only need to inject extra data for external clients. external
+  // clients only retrieve CollectionStories within the context / as
+  // children of Collections, so we start branching there.
+
+  // all retrieval queries in prisma begin with 'find' - findMany, findFirst,
+  // findMany. i do *not* like hard coding this 'find' string here. it's
+  // setting us up for a bug when merging dependabot PRs.
+  if (
+    String(params.model) === 'Collection' &&
+    params.action.startsWith('find')
+  ) {
+    // THIS IS WEIRD
+    // even though it is defined in this file, notice we are calling the
+    // `injectItemIntoCollectionStories` function with the namespace given in
+    // the `import` statement above. this is so we can spy on this function
+    // in tests.
+    if (Array.isArray(results)) {
+      results = results.map(PrismaMiddleware.injectItemIntoCollectionStories);
+    } else {
+      results = PrismaMiddleware.injectItemIntoCollectionStories(results);
+    }
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Goal

add `item` property to `CollectionStory` to enable retrieval of the related Parser Item via URL through our federated graph.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-762

## Implementation Decisions

i do *not* love middleware, particularly when it's hard-coded against external API method names. however, i don't know of a better way to achieve this right now, so here we are. there are tests at least?