### PR TITLE
fix(rds) - ensure RDS doesn't auto-pause

### DIFF
--- a/.aws/src/rds.ts
+++ b/.aws/src/rds.ts
@@ -16,6 +16,7 @@ export function createRds(scope: Construct, pocketVpc: PocketVPC) {
         {
           minCapacity: config.rds.minCapacity,
           maxCapacity: config.rds.maxCapacity,
+          autoPause: false,
         },
       ],
     },


### PR DESCRIPTION
## Goal

After a period of inactivity, RDS pauses and has a capacity of 0. This PR prevents that

a copy of #21 with a cleaned up commit history