### PR TITLE
fix(updateAuthor) - solidify logic on slugs when updating author

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -24,6 +24,7 @@ input CreateCollectionAuthorInput {
 input UpdateCollectionAuthorInput {
   externalId: String!
   name: String!
+  slug: String
   bio: Markdown
   imageUrl: Url
   active: Boolean

--- a/src/database/mutations.ts
+++ b/src/database/mutations.ts
@@ -33,7 +33,7 @@ export async function createAuthor(
   });
 
   if (slugExists) {
-    throw new Error(`Author with slug "${data.slug}" already exists`);
+    throw new Error(`An author with the slug "${data.slug}" already exists`);
   }
 
   return db.collectionAuthor.create({ data: { ...data } });
@@ -51,19 +51,20 @@ export async function updateAuthor(
     throw new Error('externalId must be provided.');
   }
 
-  const slug = slugify(data.name, config.slugify);
+  // only attempt to update the slug if specifically asked
+  if (data.slug) {
+    const slugExists = await db.collectionAuthor.count({
+      where: { slug: data.slug, externalId: { not: data.externalId } },
+    });
 
-  const slugExists = await db.collectionAuthor.count({
-    where: { slug, externalId: { not: data.externalId } },
-  });
-
-  if (slugExists) {
-    throw new Error(`An author with the slug "${slug}" already exists`);
+    if (slugExists) {
+      throw new Error(`An author with the slug "${data.slug}" already exists`);
+    }
   }
 
   return db.collectionAuthor.update({
     where: { externalId: data.externalId },
-    data: { ...data, slug },
+    data: { ...data },
   });
 }
 

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -15,6 +15,7 @@ export type CreateCollectionAuthorInput = {
 export type UpdateCollectionAuthorInput = {
   externalId: string;
   name: string;
+  slug?: string;
   bio?: string;
   imageUrl?: string;
   active?: boolean;


### PR DESCRIPTION
## Goal

update/solidify logic for slugs when updating a CollectionAuthor

- allow slug to be sent via graphql API
- do not regenerate a slug unless specifically asked
- add some tests

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-775

## Implementation Decisions

as slugs will likely eventually be used in URLs, we shouldn't auto-change slugs when updating an author's name. slug changes should be specifically requested from the admin.