### PR TITLE
feat(tests) - add tests for remaining collection author/story db ops

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -98,7 +98,7 @@ type Query {
   """
   Retrieves a CollectionStory by a combination of collectionId and url.
   """
-  getCollectionStory(collectionId: Int!, url: String): CollectionStory
+  getCollectionStory(externalId: String): CollectionStory
 }
 
 type Mutation {

--- a/src/admin/resolvers.ts
+++ b/src/admin/resolvers.ts
@@ -182,10 +182,10 @@ export const resolvers = {
     },
     getCollectionStory: async (
       _source,
-      { collectionId, url },
+      { externalId },
       { db }
     ): Promise<CollectionStory> => {
-      const collectionStory = await getCollectionStory(db, collectionId, url);
+      const collectionStory = await getCollectionStory(db, externalId);
 
       return {
         ...collectionStory,

--- a/src/database/queries.ts
+++ b/src/database/queries.ts
@@ -187,10 +187,9 @@ export async function countAuthors(db: PrismaClient): Promise<number> {
  */
 export async function getCollectionStory(
   db: PrismaClient,
-  collectionId: number,
-  url: string
+  externalId: string
 ): Promise<CollectionStory> {
   return await db.collectionStory.findUnique({
-    where: { collectionIdUrl: { collectionId, url } },
+    where: { externalId },
   });
 }

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -3,6 +3,7 @@ import {
   Collection,
   CollectionAuthor,
   CollectionStatus,
+  CollectionStory,
   PrismaClient,
   Prisma,
 } from '@prisma/client';
@@ -56,23 +57,52 @@ export async function createCollectionHelper(
   }
 
   for (let i = 0; i < getRandomInt(2, 6); i++) {
-    await prisma.collectionStory.create({
-      data: {
-        collectionId: collection.id,
-        url: faker.internet.url(),
-        title: faker.lorem.sentence(),
-        excerpt: faker.lorem.paragraph(),
-        imageUrl: faker.image.imageUrl(),
-        authors: JSON.stringify([
-          { name: `${faker.name.firstName()} ${faker.name.lastName()}` },
-          { name: `${faker.name.firstName()} ${faker.name.lastName()}` },
-        ]),
-        publisher: faker.company.companyName(),
-      },
-    });
+    await createCollectionStoryHelper(
+      prisma,
+      collection.id,
+      faker.internet.url(),
+      faker.lorem.sentence(),
+      faker.lorem.paragraph(),
+      faker.image.imageUrl(),
+      [
+        { name: `${faker.name.firstName()} ${faker.name.lastName()}` },
+        { name: `${faker.name.firstName()} ${faker.name.lastName()}` },
+      ],
+      faker.company.companyName()
+    );
   }
 
   return collection;
+}
+
+export async function createCollectionStoryHelper(
+  prisma: PrismaClient,
+  collectionId: number,
+  url: string,
+  title: string,
+  excerpt: string,
+  imageUrl: string,
+  authors: { name: string }[],
+  publisher: string,
+  sortOrder?: number
+): Promise<CollectionStory> {
+  const data: any = {
+    collectionId,
+    url,
+    title,
+    excerpt,
+    imageUrl,
+    authors: JSON.stringify(authors),
+    publisher,
+  };
+
+  if (sortOrder) {
+    data.sortOrder = sortOrder;
+  }
+
+  return await prisma.collectionStory.create({
+    data,
+  });
 }
 
 export async function clear(prisma: PrismaClient): Promise<void> {


### PR DESCRIPTION
## Goal

make sure all collection story and collection author queries and mutations have tests.

- created a new helper for collection stories
- refactored `getCollectionStory` to take an externalId

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-770

## Implementation Decisions

as all other simple `get{Entity}` queries rely on `externalId`, and since we only get CollectionStory from the admin, figured it was best to follow convention for `getCollectionStory`.
