### PR TITLE
fix(admin schema) - fix imageUrl type (String -> Url)

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -38,7 +38,7 @@ input CreateCollectionInput {
   title: String!
   excerpt: Markdown
   intro: Markdown
-  imageUrl: String
+  imageUrl: Url
   status: CollectionStatus
   authorExternalId: String!
 }
@@ -49,7 +49,7 @@ input UpdateCollectionInput {
   title: String!
   excerpt: Markdown!
   intro: Markdown
-  imageUrl: String
+  imageUrl: Url
   status: CollectionStatus!
   authorExternalId: String!
 }


### PR DESCRIPTION
## Goal

`imageUrl` should use our `Url` scalar type instead of `String` (even though it's just a string in the end).

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-778