### PR TITLE
[BACK-786] Return authors and stories after collection mutation

### DIFF
--- a/src/database/mutations.integration.ts
+++ b/src/database/mutations.integration.ts
@@ -328,7 +328,11 @@ describe('mutations', () => {
       });
 
       it('should return authors and stories when a collection is updated', async () => {
-        const initial = await createCollectionHelper(db, 'first iteration', author);
+        const initial = await createCollectionHelper(
+          db,
+          'first iteration',
+          author
+        );
 
         const data: UpdateCollectionInput = {
           externalId: initial.externalId,

--- a/src/database/mutations.ts
+++ b/src/database/mutations.ts
@@ -1,5 +1,4 @@
 import {
-  Collection,
   CollectionAuthor,
   CollectionStatus,
   CollectionStory,


### PR DESCRIPTION
## Goal

Make sure `authors` and `stories` are returned as part of a collection mutation (`create` and `update`)

## Reference

Tickets: BACK-786
