### PR TITLE
fix(CollectionStory) - include authors when deleting

### DIFF
--- a/src/database/mutations.integration.ts
+++ b/src/database/mutations.integration.ts
@@ -511,10 +511,14 @@ describe('mutations', () => {
         story = await createCollectionStory(db, data);
       });
 
-      it('should delete a collection story', async () => {
+      it('should delete a collection story and return the deleted data', async () => {
         const result = await deleteCollectionStory(db, story.externalId);
 
-        expect(result).toBeTruthy();
+        // should have direct model data
+        expect(result.title).toEqual(story.title);
+
+        // should have related author data
+        expect(result.authors.length).toBeGreaterThan(0);
 
         // make sure the story is really gone
         const found = await getCollectionStory(db, story.externalId);

--- a/src/database/mutations.ts
+++ b/src/database/mutations.ts
@@ -1,7 +1,6 @@
 import {
   CollectionAuthor,
   CollectionStatus,
-  CollectionStory,
   Image,
   ImageEntityType,
   PrismaClient,
@@ -257,7 +256,7 @@ export async function updateCollectionStory(
 export async function deleteCollectionStory(
   db: PrismaClient,
   externalId: string
-): Promise<CollectionStory> {
+): Promise<CollectionStoryWithAuthors> {
   // get the existing story for the internal id
   const existingStory = await getCollectionStory(db, externalId);
 
@@ -269,7 +268,14 @@ export async function deleteCollectionStory(
   });
 
   // delete the story
-  return await db.collectionStory.delete({ where: { externalId } });
+  await db.collectionStory.delete({
+    where: { externalId },
+  });
+
+  // to conform with the scheam, we need to return a CollectionStory with
+  // authors, which can't be done in the `.delete` call above because we
+  // already deleted the authors.
+  return existingStory;
 }
 
 /**


### PR DESCRIPTION
## Goal

to conform to the graphql schema, we need to include authors when deleting a CollectionStory.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-802

## Implementation Decisions

did this in the easiest way i could see. happy to consider an alternative.