### PR TITLE
Make @pocket-ci codeowner for auto merging dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
-#All Files/PRS
+# Make @pocket-ci codeowner such that it can approve Dependabot PRs automatically.
+*                         @pocket-ci
+
+# This latter rule takes precedence, such that only we are assigned code reviews.
 *                         @pocket/backend


### PR DESCRIPTION
## Goal
Fix [auto-merging issue](https://github.com/Pocket/collection-api/pull/91#issuecomment-840057828): 
> Dependabot tried to merge this PR, but received the following error from GitHub:

> Waiting on code owner review from Pocket/backend.

