### PR TITLE
Try to fix auto-merge error

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,7 +3,7 @@
 name: auto-merge
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   auto-merge:


### PR DESCRIPTION
## Goal
Try to fix the following error in [the auto-merge job](https://github.com/Pocket/collection-api/runs/2603499021?check_suite_focus=true).

> Error: Input required and not supplied: github-token

Other users are experiencing this error too: https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/60

If this doesn't work, we could consider switching to [Renovate](https://github.com/marketplace/renovate), an alternative for Dependabot.