### PR TITLE
feat(mutation) - create mutation to update only CollectionStory `sortOrder`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "apollo-server-plugin-response-cache": "^0.8.0",
         "aws-sdk": "^2.908.0",
         "aws-xray-sdk-core": "^3.3.3",
-        "aws-xray-sdk-express": "^3.2.0",
+        "aws-xray-sdk-express": "^3.3.3",
         "graphql": "^15.5.0",
         "graphql-upload": "^11.0.0",
         "mime-types": "^2.1.30",
@@ -2710,9 +2710,9 @@
       }
     },
     "node_modules/aws-xray-sdk-express": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/aws-xray-sdk-express/-/aws-xray-sdk-express-3.3.1.tgz",
-      "integrity": "sha512-O+H+UQBjlmmbL/d1i7K9bFDpjamy6nFf/9Xcpyufzzpj2CRahQ8t6opatT3908nPeyeMakxJHSZaS7/eFDpIPA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-express/-/aws-xray-sdk-express-3.3.3.tgz",
+      "integrity": "sha512-VLDfpWWlYUEqA/f3OWaPHk6lAlONrAbG8ECcCPKT3skhWe8LL3bCDFZJOs08V+3ZgBCjm8iMStlXxnNu+XHevw==",
       "dependencies": {
         "@types/express": "*"
       },
@@ -2720,7 +2720,7 @@
         "node": ">= 10.x"
       },
       "peerDependencies": {
-        "aws-xray-sdk-core": "^3.3.1"
+        "aws-xray-sdk-core": "^3.3.3"
       }
     },
     "node_modules/aws4": {
@@ -13131,9 +13131,9 @@
       }
     },
     "aws-xray-sdk-express": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/aws-xray-sdk-express/-/aws-xray-sdk-express-3.3.1.tgz",
-      "integrity": "sha512-O+H+UQBjlmmbL/d1i7K9bFDpjamy6nFf/9Xcpyufzzpj2CRahQ8t6opatT3908nPeyeMakxJHSZaS7/eFDpIPA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-express/-/aws-xray-sdk-express-3.3.3.tgz",
+      "integrity": "sha512-VLDfpWWlYUEqA/f3OWaPHk6lAlONrAbG8ECcCPKT3skhWe8LL3bCDFZJOs08V+3ZgBCjm8iMStlXxnNu+XHevw==",
       "requires": {
         "@types/express": "*"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "apollo-server-plugin-response-cache": "^0.8.0",
     "aws-sdk": "^2.908.0",
     "aws-xray-sdk-core": "^3.3.3",
-    "aws-xray-sdk-express": "^3.2.0",
+    "aws-xray-sdk-express": "^3.3.3",
     "graphql": "^15.5.0",
     "graphql-upload": "^11.0.0",
     "mime-types": "^2.1.30",

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -81,6 +81,22 @@ input UpdateCollectionStoryInput {
   sortOrder: Int
 }
 
+input UpdateCollectionStorySortOrderInput {
+  externalId: String!
+  sortOrder: Int!
+}
+
+type CollectionImageUrl {
+  url: String!
+}
+
+input CollectionImageUploadInput {
+  image: Upload!
+  width: Int!
+  height: Int!
+  fileSizeBytes: Int!
+}
+
 type Query {
   searchCollections(
     filters: SearchCollectionsFilters!
@@ -105,24 +121,43 @@ type Query {
   getCollectionStory(externalId: String!): CollectionStory
 }
 
-type CollectionImageUrl {
-  url: String!
-}
-
-input CollectionImageUploadInput {
-  image: Upload!
-  width: Int!
-  height: Int!
-  fileSizeBytes: Int!
-}
-
 type Mutation {
+  """
+  Creates a CollectionAuthor.
+  """
   createCollectionAuthor(data: CreateCollectionAuthorInput!): CollectionAuthor!
+  """
+  Updates a CollectionAuthor.
+  """
   updateCollectionAuthor(data: UpdateCollectionAuthorInput!): CollectionAuthor!
+  """
+  Creates a Collection.
+  """
   createCollection(data: CreateCollectionInput!): Collection!
+  """
+  Updates a Collection.
+  """
   updateCollection(data: UpdateCollectionInput!): Collection!
+  """
+  Creates a CollectionStory.
+  """
   createCollectionStory(data: CreateCollectionStoryInput!): CollectionStory!
+  """
+  Updates a CollectionStory.
+  """
   updateCollectionStory(data: UpdateCollectionStoryInput!): CollectionStory!
+  """
+  Updates only the `sortOrder` property of a CollectionStory. Dedicated to ordering stories within the UI.
+  """
+  updateCollectionStorySortOrder(
+    data: UpdateCollectionStorySortOrderInput!
+  ): CollectionStory!
+  """
+  Deletes a CollectionStory. Also deletes all the related CollectionStoryAuthor records.
+  """
   deleteCollectionStory(externalId: String!): CollectionStory!
+  """
+  Uploads an image to S3. Does *not* save the image to any entity (CollectionAuthor/Collection/CollectionStory).
+  """
   collectionImageUpload(data: CollectionImageUploadInput!): CollectionImageUrl!
 }

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -14,6 +14,7 @@ import {
   updateCollection,
   updateCollectionAuthor,
   updateCollectionStory,
+  updateCollectionStorySortOrder,
 } from './mutations';
 
 export const resolvers = {
@@ -26,6 +27,7 @@ export const resolvers = {
     updateCollectionStory,
     deleteCollectionStory,
     collectionImageUpload,
+    updateCollectionStorySortOrder,
   },
   Query: {
     getCollection,

--- a/src/admin/resolvers/mutations.ts
+++ b/src/admin/resolvers/mutations.ts
@@ -15,6 +15,7 @@ import {
   UpdateCollectionAuthorInput,
   UpdateCollectionInput,
   UpdateCollectionStoryInput,
+  UpdateCollectionStorySortOrderInput,
 } from '../../database/types';
 import {
   associateImageWithEntity,
@@ -26,6 +27,7 @@ import {
   updateAuthor,
   updateCollection as dbUpdateCollection,
   updateCollectionStory as dbUpdateCollectionStory,
+  updateCollectionStorySortOrder as dbUpdateCollectionStorySortOrder,
 } from '../../database/mutations';
 import { S3 } from 'aws-sdk';
 import { uploadImage } from '../../aws/upload';
@@ -168,6 +170,27 @@ export async function updateCollectionStory(
     db,
     data,
     dbUpdateCollectionStory,
+    ImageEntityType.COLLECTION_STORY
+  );
+}
+
+/**
+ * @param parent
+ * @param data
+ * @param db
+ */
+export async function updateCollectionStorySortOrder(
+  parent,
+  { data },
+  { db }
+): Promise<CollectionStory> {
+  return await executeMutation<
+    UpdateCollectionStorySortOrderInput,
+    CollectionStory
+  >(
+    db,
+    data,
+    dbUpdateCollectionStorySortOrder,
     ImageEntityType.COLLECTION_STORY
   );
 }

--- a/src/database/mutations.CollectionStory.integration.ts
+++ b/src/database/mutations.CollectionStory.integration.ts
@@ -13,6 +13,7 @@ import {
   createCollectionStory,
   deleteCollectionStory,
   updateCollectionStory,
+  updateCollectionStorySortOrder,
 } from './mutations';
 
 const db = new PrismaClient();
@@ -145,7 +146,7 @@ describe('mutations: CollectionStory', () => {
       expect(updated.sortOrder).toEqual(updateData.sortOrder);
     });
 
-    it('should update the collection story authors and return them property sorted', async () => {
+    it('should update the collection story authors and return them properly sorted', async () => {
       const updateData: UpdateCollectionStoryInput = {
         externalId: story.externalId,
         url: 'https://www.lebowskifest.com/bowling',
@@ -168,6 +169,51 @@ describe('mutations: CollectionStory', () => {
       expect(updated.authors[0].name).toEqual('brandt');
       expect(updated.authors[1].name).toEqual('karl');
       expect(updated.authors[2].name).toEqual('maude');
+    });
+  });
+
+  describe('updateCollectionStorySortOrder', () => {
+    let story;
+
+    beforeEach(async () => {
+      const data: CreateCollectionStoryInput = {
+        collectionExternalId: collection.externalId,
+        url: 'https://www.lebowskifest.com/',
+        title: 'lebowski fest',
+        excerpt: 'when will the next fest be?',
+        imageUrl: 'idk',
+        authors: [
+          { name: 'donny', sortOrder: 1 },
+          { name: 'walter', sortOrder: 2 },
+        ],
+        publisher: 'little lebowskis',
+        sortOrder: 4,
+      };
+
+      story = await createCollectionStory(db, data);
+    });
+
+    it('should update the sortOrder of a collection story', async () => {
+      const updated = await updateCollectionStorySortOrder(db, {
+        externalId: story.externalId,
+        sortOrder: story.sortOrder + 1,
+      });
+
+      expect(updated.sortOrder).toEqual(story.sortOrder + 1);
+    });
+
+    it('should not update any other properties when updating sortOrder', async () => {
+      const updated = await updateCollectionStorySortOrder(db, {
+        externalId: story.externalId,
+        sortOrder: 3,
+      });
+
+      expect(updated.title).toEqual(story.title);
+      expect(updated.url).toEqual(story.url);
+      expect(updated.excerpt).toEqual(story.excerpt);
+      expect(updated.imageUrl).toEqual(story.imageUrl);
+      expect(updated.authors).toEqual(story.authors);
+      expect(updated.publisher).toEqual(story.publisher);
     });
   });
 

--- a/src/database/mutations.ts
+++ b/src/database/mutations.ts
@@ -19,6 +19,7 @@ import {
   UpdateCollectionAuthorInput,
   UpdateCollectionInput,
   UpdateCollectionStoryInput,
+  UpdateCollectionStorySortOrderInput,
 } from './types';
 
 /**
@@ -243,6 +244,30 @@ export async function updateCollectionStory(
       authors: {
         create: data.authors,
       },
+    },
+    include: {
+      authors: {
+        orderBy: [{ sortOrder: 'asc' }],
+      },
+    },
+  });
+}
+
+/**
+ * mutation dedicated to re-ordering stories within a collection
+ * @param db
+ * @param externalId
+ * @param sortOrder
+ * @returns
+ */
+export async function updateCollectionStorySortOrder(
+  db: PrismaClient,
+  data: UpdateCollectionStorySortOrderInput
+): Promise<CollectionStoryWithAuthors> {
+  return db.collectionStory.update({
+    where: { externalId: data.externalId },
+    data: {
+      sortOrder: data.sortOrder,
     },
     include: {
       authors: {

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -67,6 +67,11 @@ export type UpdateCollectionStoryInput = Omit<
   externalId: string;
 };
 
+export type UpdateCollectionStorySortOrderInput = {
+  externalId: string;
+  sortOrder: number;
+};
+
 export type SearchCollectionsFilters = {
   author?: string;
   title?: string;


### PR DESCRIPTION
## Goal

creates a dedicated mutation to updating the `sortOrder` of a `CollectionStory`. this is necessary to prevent us from calling the full `updateCollectionStory` mutation when dragging and dropping stories to re-order them. results in a smaller data payload and de-couples updating a `CollectionStory` (title, excerpt, image, etc) from simply re-ordering it.

- updates an AWS package to fix build errors
- adds some docs in graphql admin schema

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-823