### PR TITLE
[BACK-855] API - allow empty/null authors on CollectionStory

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -65,7 +65,7 @@ input CreateCollectionStoryInput {
   title: String!
   excerpt: Markdown!
   imageUrl: Url!
-  authors: [CollectionStoryAuthorInput]!
+  authors: [CollectionStoryAuthorInput!]!
   publisher: String!
   sortOrder: Int
 }
@@ -76,7 +76,7 @@ input UpdateCollectionStoryInput {
   title: String!
   excerpt: Markdown!
   imageUrl: Url!
-  authors: [CollectionStoryAuthorInput]!
+  authors: [CollectionStoryAuthorInput!]!
   publisher: String!
   sortOrder: Int
 }

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -66,7 +66,7 @@ type CollectionStory @key(fields: "item { givenUrl }") {
   title: String!
   excerpt: Markdown!
   imageUrl: Url
-  authors: [CollectionStoryAuthor]!
+  authors: [CollectionStoryAuthor!]!
   publisher: String
   sortOrder: Int
   item: Item


### PR DESCRIPTION
## Goal

Insert purpose of pull request

Allow users to send collection stories with no authors specified - sometimes articles don't have any author data.

Tickets:

- https://getpocket.atlassian.net/browse/BACK-855

## Implementation Decisions

- Followed instructions in JIRA ticket to allow optional authors
on CollectionStory

- Added tests

- Added a script to package.json to be able to rerun integration tests
on every code change.