### PR TITLE
Add language field to collection mutations in schema

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -44,6 +44,7 @@ input CreateCollectionInput {
   excerpt: Markdown
   intro: Markdown
   imageUrl: Url
+  language: String!
   status: CollectionStatus
   authorExternalId: String!
   curationCategoryExternalId: String
@@ -58,6 +59,7 @@ input UpdateCollectionInput {
   excerpt: Markdown!
   intro: Markdown
   imageUrl: Url
+  language: String!
   status: CollectionStatus!
   authorExternalId: String!
   curationCategoryExternalId: String

--- a/src/database/mutations/Collection.ts
+++ b/src/database/mutations/Collection.ts
@@ -25,7 +25,7 @@ export async function createCollection(
     throw new Error(`A collection with the slug "${data.slug}" already exists`);
   }
 
-  // standardize lanuage format
+  // standardize language format
   data.language = data.language.toLowerCase();
 
   if (!isSupportedLanguage(data.language)) {
@@ -135,7 +135,7 @@ export async function updateCollection(
     }
   }
 
-  // standardize lanuage format
+  // standardize language format
   data.language = data.language.toLowerCase();
 
   if (!isSupportedLanguage(data.language)) {


### PR DESCRIPTION
## Goal

A follow-up fix to #282 - mutation inputs in the GraphQL schema were missing the new `language` field. Discovered while adding language support to the frontend.
