### PR TITLE
[BACK-755] Add an extra partnership query

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -257,6 +257,11 @@ type Query {
   Retrieves a CollectionPartnerAssociation by externalId
   """
   getCollectionPartnerAssociation(externalId: String!): CollectionPartnerAssociation
+  """
+  Retrieves a CollectionPartnerAssociation by the externalId of the collection
+  it is related to.
+  """
+  getCollectionPartnerAssociationForCollection(externalId: String!): CollectionPartnerAssociation
 }
 
 type Mutation {

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -10,6 +10,7 @@ import {
   getLanguages,
   getIABCategories,
   searchCollections,
+  getCollectionPartnerAssociationForCollection,
 } from './queries';
 import {
   collectionImageUpload,
@@ -64,6 +65,7 @@ export const resolvers = {
     getCollectionPartner,
     getCollectionPartners,
     getCollectionPartnerAssociation,
+    getCollectionPartnerAssociationForCollection,
     getCollectionStory,
     getCurationCategories,
     getIABCategories,

--- a/src/admin/resolvers/queries.ts
+++ b/src/admin/resolvers/queries.ts
@@ -9,6 +9,7 @@ import {
   getAuthors,
   getCollection as dbGetCollection,
   getCollectionPartnerAssociation as dbGetCollectionPartnerAssociation,
+  getCollectionPartnerAssociationForCollection as dbGetCollectionPartnerAssociationForCollection,
   getCollectionStory as dbGetCollectionStory,
   getCurationCategories as dbGetCurationCategories,
   searchCollections as dbSearchCollections,
@@ -201,4 +202,17 @@ export async function getCollectionPartnerAssociation(
   { db }
 ): Promise<CollectionPartnerAssociation> {
   return dbGetCollectionPartnerAssociation(db, externalId);
+}
+
+/**
+ * @param parent
+ * @param externalId
+ * @param db
+ */
+export async function getCollectionPartnerAssociationForCollection(
+  parent,
+  { externalId },
+  { db }
+): Promise<CollectionPartnerAssociation> {
+  return dbGetCollectionPartnerAssociationForCollection(db, externalId);
 }

--- a/src/database/queries.ts
+++ b/src/database/queries.ts
@@ -21,4 +21,7 @@ export {
   getPartner,
   getPartners,
 } from './queries/CollectionPartner';
-export { getCollectionPartnerAssociation } from './queries/CollectionPartnerAssociation';
+export {
+  getCollectionPartnerAssociation,
+  getCollectionPartnerAssociationForCollection,
+} from './queries/CollectionPartnerAssociation';

--- a/src/database/queries/CollectionPartnerAssociation.integration.ts
+++ b/src/database/queries/CollectionPartnerAssociation.integration.ts
@@ -1,7 +1,12 @@
 import { CollectionPartnershipType, PrismaClient } from '@prisma/client';
-import { getCollectionPartnerAssociation } from './CollectionPartnerAssociation';
+import {
+  getCollectionPartnerAssociation,
+  getCollectionPartnerAssociationForCollection,
+} from './CollectionPartnerAssociation';
 import {
   clear as clearDb,
+  createAuthorHelper,
+  createCollectionHelper,
   createCollectionPartnerAssociationHelper,
 } from '../../test/helpers';
 
@@ -38,6 +43,44 @@ describe('queries: CollectionPartnerAssociation', () => {
       const found = await getCollectionPartnerAssociation(
         db,
         association.externalId + 'typo'
+      );
+
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('getCollectionPartnerAssociationForCollection', () => {
+    it('should get an association by the externalId of the collection it references', async () => {
+      const author = await createAuthorHelper(db, 'Any Name');
+      const collection = await createCollectionHelper(db, {
+        title: 'A test collection',
+        author,
+      });
+
+      const association = await createCollectionPartnerAssociationHelper(db, {
+        type: CollectionPartnershipType.PARTNERED,
+        collection,
+      });
+
+      const found = await getCollectionPartnerAssociationForCollection(
+        db,
+        collection.externalId
+      );
+
+      expect(found).not.toBeNull();
+      expect(association.externalId).toEqual(found.externalId);
+    });
+
+    it('should fail on an invalid collection externalId', async () => {
+      const author = await createAuthorHelper(db, 'Any Name');
+      const collection = await createCollectionHelper(db, {
+        title: 'A test collection without a partnership',
+        author,
+      });
+
+      const found = await getCollectionPartnerAssociationForCollection(
+        db,
+        collection.externalId
       );
 
       expect(found).toBeNull();

--- a/src/database/queries/CollectionPartnerAssociation.ts
+++ b/src/database/queries/CollectionPartnerAssociation.ts
@@ -23,3 +23,31 @@ export async function getCollectionPartnerAssociation(
 
   return association;
 }
+
+/**
+ * @param db
+ * @param externalId
+ */
+export async function getCollectionPartnerAssociationForCollection(
+  db: PrismaClient,
+  externalId: string
+): Promise<CollectionPartnerAssociation> {
+  const association = db.collectionPartnership.findFirst({
+    where: {
+      collection: {
+        externalId,
+      },
+    },
+    include: {
+      partner: true,
+    },
+  });
+
+  if (!association) {
+    throw new Error(
+      `Association for collection with external ID: ${externalId} does not exist.`
+    );
+  }
+
+  return association;
+}


### PR DESCRIPTION
## Goal

The frontend is having a hard time refreshing the partnership component if
the CollectionPartnerAssociation entity is queried by the value of its 'externalId'
field.

To fix this, I've added a new query getCollectionPartnerAssociationForCollection
- this one requests a collection external id rather the association's own external id.

I have left the original getCollectionPartnerAssociation intact even though it's currently
not used anywhere on the frontend.

## Todos

- [x] Query works.
- [x] Query has tests.
