### PR TITLE
[BACK-755] Add 'fromPartner' field to create/update story mutation input types

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -89,7 +89,7 @@ input CreateCollectionStoryInput {
   authors: [CollectionStoryAuthorInput!]!
   publisher: String!
   sortOrder: Int
-  fromPartner: Boolean!
+  fromPartner: Boolean
 }
 
 input UpdateCollectionStoryInput {
@@ -101,7 +101,7 @@ input UpdateCollectionStoryInput {
   authors: [CollectionStoryAuthorInput!]!
   publisher: String!
   sortOrder: Int
-  fromPartner: Boolean!
+  fromPartner: Boolean
 }
 
 input UpdateCollectionStorySortOrderInput {

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -86,6 +86,7 @@ input CreateCollectionStoryInput {
   authors: [CollectionStoryAuthorInput!]!
   publisher: String!
   sortOrder: Int
+  fromPartner: Boolean!
 }
 
 input UpdateCollectionStoryInput {
@@ -97,6 +98,7 @@ input UpdateCollectionStoryInput {
   authors: [CollectionStoryAuthorInput!]!
   publisher: String!
   sortOrder: Int
+  fromPartner: Boolean!
 }
 
 input UpdateCollectionStorySortOrderInput {

--- a/src/database/mutations/CollectionStory.integration.ts
+++ b/src/database/mutations/CollectionStory.integration.ts
@@ -53,6 +53,7 @@ describe('mutations: CollectionStory', () => {
           { name: 'walter', sortOrder: 2 },
         ],
         publisher: 'little lebowskis',
+        fromPartner: false,
       };
     });
 
@@ -152,6 +153,7 @@ describe('mutations: CollectionStory', () => {
         ],
         publisher: 'little lebowskis',
         sortOrder: 4,
+        fromPartner: false,
       };
 
       story = await createCollectionStory(db, data);
@@ -170,6 +172,7 @@ describe('mutations: CollectionStory', () => {
         ],
         publisher: 'the cast',
         sortOrder: 3,
+        fromPartner: true,
       };
 
       const updated = await updateCollectionStory(db, updateData);
@@ -196,6 +199,7 @@ describe('mutations: CollectionStory', () => {
         ],
         publisher: 'the cast',
         sortOrder: 3,
+        fromPartner: false,
       };
 
       const updated = await updateCollectionStory(db, updateData);
@@ -217,6 +221,7 @@ describe('mutations: CollectionStory', () => {
         authors: [],
         publisher: 'the cast',
         sortOrder: 3,
+        fromPartner: false,
       };
 
       const updated = await updateCollectionStory(db, updateData);
@@ -237,6 +242,7 @@ describe('mutations: CollectionStory', () => {
         ],
         publisher: 'the cast',
         sortOrder: 3,
+        fromPartner: false,
       };
 
       const updated = await updateCollectionStory(db, updateData);
@@ -258,6 +264,7 @@ describe('mutations: CollectionStory', () => {
         ],
         publisher: 'random penguin',
         sortOrder: 5,
+        fromPartner: false,
       };
 
       await createCollectionStory(db, createData);
@@ -275,6 +282,7 @@ describe('mutations: CollectionStory', () => {
         ],
         publisher: 'random penguin',
         sortOrder: 1,
+        fromPartner: false,
       };
 
       // Return a custom error message instead of "Unique constraint failed..."
@@ -303,6 +311,7 @@ describe('mutations: CollectionStory', () => {
         ],
         publisher: 'random penguin',
         sortOrder: 5,
+        fromPartner: false,
       };
 
       await createCollectionStory(db, createData);
@@ -320,6 +329,7 @@ describe('mutations: CollectionStory', () => {
         ],
         publisher: 'random penguin',
         sortOrder: 1,
+        fromPartner: false,
       };
 
       const updated = await updateCollectionStory(db, updateData);
@@ -344,6 +354,7 @@ describe('mutations: CollectionStory', () => {
         ],
         publisher: 'little lebowskis',
         sortOrder: 4,
+        fromPartner: false,
       };
 
       story = await createCollectionStory(db, data);
@@ -389,6 +400,7 @@ describe('mutations: CollectionStory', () => {
         ],
         publisher: 'little lebowskis',
         sortOrder: 4,
+        fromPartner: false,
       };
 
       story = await createCollectionStory(db, data);
@@ -435,6 +447,7 @@ describe('mutations: CollectionStory', () => {
         ],
         publisher: 'little lebowskis',
         sortOrder: 4,
+        fromPartner: false,
       };
 
       story = await createCollectionStory(db, data);

--- a/src/database/mutations/CollectionStory.integration.ts
+++ b/src/database/mutations/CollectionStory.integration.ts
@@ -53,7 +53,6 @@ describe('mutations: CollectionStory', () => {
           { name: 'walter', sortOrder: 2 },
         ],
         publisher: 'little lebowskis',
-        fromPartner: false,
       };
     });
 
@@ -72,6 +71,13 @@ describe('mutations: CollectionStory', () => {
 
       // default sort order of 0 should be there
       expect(story.sortOrder).toEqual(0);
+    });
+
+    it('should create a collection story with a default `fromPartner` value', async () => {
+      const story = await createCollectionStory(db, data);
+
+      // default 'fromPartner' value of 'false' should be present
+      expect(story.fromPartner).toEqual(false);
     });
 
     it('should return story authors sorted correctly', async () => {
@@ -335,6 +341,24 @@ describe('mutations: CollectionStory', () => {
       const updated = await updateCollectionStory(db, updateData);
 
       expect(updated.url).toEqual(updateData.url);
+    });
+
+    it('should allow updates with optional fields omitted in input data', async () => {
+      const updateData: UpdateCollectionStoryInput = {
+        externalId: story.externalId,
+        url: 'https://www.lebowskifest.com/bowling',
+        title: 'a fest of lebowskis',
+        excerpt: 'new excerpt',
+        imageUrl: 'new image url',
+        authors: [],
+        publisher: 'the cast',
+      };
+
+      const updated = await updateCollectionStory(db, updateData);
+
+      // The two optional fields should stay as they are
+      expect(updated.sortOrder).toEqual(story.sortOrder);
+      expect(updated.fromPartner).toEqual(story.fromPartner);
     });
   });
 

--- a/src/database/queries/CollectionStory.integration.ts
+++ b/src/database/queries/CollectionStory.integration.ts
@@ -36,6 +36,7 @@ describe('queries: CollectionStory', () => {
         imageUrl: 'https://some.image',
         authors: [{ name: 'donny', sortOrder: 0 }],
         publisher: 'the verge',
+        fromPartner: false,
       });
     });
 

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -81,7 +81,7 @@ export type CreateCollectionStoryInput = {
   authors: CollectionStoryAuthor[];
   publisher: string;
   sortOrder?: number;
-  fromPartner: boolean;
+  fromPartner?: boolean;
 };
 
 export type UpdateCollectionStoryInput = Omit<

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -81,6 +81,7 @@ export type CreateCollectionStoryInput = {
   authors: CollectionStoryAuthor[];
   publisher: string;
   sortOrder?: number;
+  fromPartner: boolean;
 };
 
 export type UpdateCollectionStoryInput = Omit<

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -165,6 +165,7 @@ export async function createCollectionHelper(
           },
         ],
         publisher: faker.company.companyName(),
+        fromPartner: faker.datatype.boolean(),
       });
     }
   }


### PR DESCRIPTION
## Goal

Add the new `fromPartner` field to `createCollectionStory` and `updateCollectionStory` mutations so that they can be used by the frontend. 

Note that since the new field/variable is required in these mutations this PR will break the Admin UI if merged before the rest of the frontend changes are merged.