### PR TITLE
Revert "[DEPBOT-0101]: Bump aws-sdk from 2.961.0 to 2.962.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "apollo-server-cache-redis": "^1.5.0",
         "apollo-server-express": "^2.25.1",
         "apollo-server-plugin-response-cache": "^0.9.0",
-        "aws-sdk": "^2.962.0",
         "aws-sdk": "^2.961.0",
         "aws-xray-sdk-core": "^3.3.3",
         "aws-xray-sdk-express": "^3.3.3",
@@ -2736,9 +2735,9 @@
       "integrity": "sha1-0WkB0QzOxZUWwZe5zNiTBom4E7Q="
     },
     "node_modules/aws-sdk": {
-      "version": "2.962.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.962.0.tgz",
-      "integrity": "sha512-uY87X0bQ0tFjxt/AxJM9gZDxNzz8hD7uJG4azw7fgZibBqG2eYMAw2ythkQB/B8kLPenm/jr5+FsIG28qaC63Q==",
+      "version": "2.961.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.961.0.tgz",
+      "integrity": "sha512-71ELXHWd0roRT0FW8CnqGLYGKLksHARa7Yn8LPN3mF70FJt2LuvVAyK49IChoUczTjlzS78p+Y5197Tkky4N8g==",
       "hasInstallScript": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -11403,9 +11402,9 @@
       "integrity": "sha1-0WkB0QzOxZUWwZe5zNiTBom4E7Q="
     },
     "aws-sdk": {
-      "version": "2.962.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.962.0.tgz",
-      "integrity": "sha512-uY87X0bQ0tFjxt/AxJM9gZDxNzz8hD7uJG4azw7fgZibBqG2eYMAw2ythkQB/B8kLPenm/jr5+FsIG28qaC63Q==",
+      "version": "2.961.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.961.0.tgz",
+      "integrity": "sha512-71ELXHWd0roRT0FW8CnqGLYGKLksHARa7Yn8LPN3mF70FJt2LuvVAyK49IChoUczTjlzS78p+Y5197Tkky4N8g==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "apollo-server-cache-redis": "^1.5.0",
     "apollo-server-express": "^2.25.1",
     "apollo-server-plugin-response-cache": "^0.9.0",
-    "aws-sdk": "^2.962.0",
+    "aws-sdk": "^2.961.0",
     "aws-xray-sdk-core": "^3.3.3",
     "aws-xray-sdk-express": "^3.3.3",
     "graphql": "^15.5.1",


### PR DESCRIPTION
Reverts Pocket/collection-api#324

AWS and Apollo builds are failing on `main` and any outstanding PRs that have had the latest updates from `main` merged in. Reverting this update as it's not as straightforward as it looked. 