### PR TITLE
[BACK-755] Update schema comments for queries used in tests only

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -238,7 +238,7 @@ type Query {
   """
   getCollectionPartners(page: Int, perPage: Int): CollectionPartnersResult!
   """
-  Retrieves a CollectionStory by a combination of collectionId and url.
+  Retrieves a CollectionStory by externalId. Used for tests only.
   """
   getCollectionStory(externalId: String!): CollectionStory
   """
@@ -254,7 +254,7 @@ type Query {
   """
   getLanguages: [Language!]!
   """
-  Retrieves a CollectionPartnerAssociation by externalId
+  Retrieves a CollectionPartnerAssociation by externalId. Used for tests only.
   """
   getCollectionPartnerAssociation(externalId: String!): CollectionPartnerAssociation
   """


### PR DESCRIPTION
## Goal

As discussed here: https://github.com/Pocket/collection-api/pull/327, leave the `getCollectionPartnerAssociation` query in place as it's used in integration tests instead of deleting it and update schema comments for queries used in tests only.