### PR TITLE
fix(apollo service check): use rover for subgraph check/deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,10 +52,14 @@ jobs:
     steps:
       - checkout
       - run:
-          name: install apollo
+          name: install rover
           # CircleCI needs global installs to be sudo
           command: |
-            sudo npm install -g apollo
+            # download and install Rover
+            curl -sSL https://rover.apollo.dev/nix/v0.1.0 | sh
+
+            # This allows the PATH changes to persist to the next `run` step
+            echo 'export PATH=$HOME/.rover/bin:$PATH' >> $BASH_ENV
       - run:
           name: build public schema
           # We have to send one file for the federated schema which means we have to concat our shared scheme
@@ -63,14 +67,14 @@ jobs:
           command: cat schema-shared.graphql schema-public.graphql > schema.graphql
       - run:
           name: check service
-          command: apollo service:check --graph=pocket-client-api --localSchemaFile=schema.graphql --serviceName=collection --variant=current
+          command: rover subgraph check pocket-client-api@current --schema ./schema.graphql --name=collection
       - when:
           condition:
-            equal: [ main, << pipeline.git.branch >>]
+            equal: [main, << pipeline.git.branch >>]
           steps:
             - run:
                 name: push service
-                command: apollo service:push --graph=pocket-client-api --localSchemaFile=schema.graphql --serviceURL=https://collection-api.readitlater.com/ --serviceName=collection --variant=current
+                command: rover subgraph publish pocket-client-api@current --schema ./schema.graphql --routing-url https://collection-api.readitlater.com/ --name=collection
 
   build:
     docker:
@@ -310,4 +314,3 @@ workflows:
           workspace-path: /tmp/workspace
           requires:
             - deploy_dev
-

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -5,6 +5,9 @@ input CollectionInput {
   excerpt: String!
 }
 
+"""
+available filters for searching collections
+"""
 input SearchCollectionsFilters {
   author: String
   title: String
@@ -203,8 +206,8 @@ input UpdateCollectionPartnerAssociationInput {
 }
 
 input UpdateCollectionPartnerAssociationImageUrlInput {
-    externalId: String!
-    imageUrl: Url!
+  externalId: String!
+  imageUrl: Url!
 }
 
 input DeleteCollectionPartnerAssociationInput {
@@ -256,12 +259,16 @@ type Query {
   """
   Retrieves a CollectionPartnerAssociation by externalId
   """
-  getCollectionPartnerAssociation(externalId: String!): CollectionPartnerAssociation
+  getCollectionPartnerAssociation(
+    externalId: String!
+  ): CollectionPartnerAssociation
   """
   Retrieves a CollectionPartnerAssociation by the externalId of the collection
   it is related to.
   """
-  getCollectionPartnerAssociationForCollection(externalId: String!): CollectionPartnerAssociation
+  getCollectionPartnerAssociationForCollection(
+    externalId: String!
+  ): CollectionPartnerAssociation
 }
 
 type Mutation {
@@ -365,5 +372,7 @@ type Mutation {
   """
   Deletes a CollectionPartnerAssociation.
   """
-  deleteCollectionPartnerAssociation(externalId: String!): CollectionPartnerAssociation!
+  deleteCollectionPartnerAssociation(
+    externalId: String!
+  ): CollectionPartnerAssociation!
 }


### PR DESCRIPTION
## Goal

as `apollo service:check` is now deprecated, use the suggested `rover` package instead.

## Implementation Decisions

copied off of @kschelonka's ~~paper~~ [PR](https://github.com/Pocket/list-api/pull/184/files).