### PR TITLE
[BACK-988] Uncheck 'fromPartner' flag on sponsored stories on deleting a partnership

### DIFF
--- a/src/database/mutations/CollectionPartnerAssociation.integration.ts
+++ b/src/database/mutations/CollectionPartnerAssociation.integration.ts
@@ -201,5 +201,23 @@ describe('mutations: CollectionPartnerAssociation', () => {
         deleteCollectionPartnerAssociation(db, association.externalId + 'typo')
       ).rejects.toThrow();
     });
+
+    it("should update related stories' sponsorship status", async () => {
+      const deleted = await deleteCollectionPartnerAssociation(
+        db,
+        association.externalId
+      );
+
+      // check that none of the related collection stories have 'fromPartner'
+      // set to true
+      const sponsoredStories = await db.collectionStory.findMany({
+        where: {
+          collectionId: deleted.collectionId,
+          fromPartner: true,
+        },
+      });
+
+      expect(sponsoredStories.length).toEqual(0);
+    });
   });
 });

--- a/src/database/mutations/CollectionPartnerAssociation.ts
+++ b/src/database/mutations/CollectionPartnerAssociation.ts
@@ -112,6 +112,14 @@ export async function deleteCollectionPartnerAssociation(
     },
   });
 
+  // When a collection-partner association is deleted, we need to make sure that
+  // none of the related collection stories still have a 'fromPartner' value
+  // set to true.
+  await db.collectionStory.updateMany({
+    where: { collectionId: association.collectionId, fromPartner: true },
+    data: { fromPartner: false },
+  });
+
   // to conform with the schema, we return the association
   // as it was before we deleted it
   return association;


### PR DESCRIPTION
## Goal

Make sure client apps never show a story as 'sponsored' in a non-sponsored collection.

Tickets:

- https://getpocket.atlassian.net/browse/BACK-988

## Implementation Decisions

- The 'deleteCollectionPartnerAssociation' mutation now looks for all sponsored stories
in the related collection and updates the 'fromPartner' flag to 'false' for those.

- Added an extra integration test.
