### PR TITLE
[BACK-986] Add 'REVIEW' status and allow it in 'getCollectionBySlug' query.

### DIFF
--- a/prisma/migrations/20210823001422_add_review_status_to_collections/migration.sql
+++ b/prisma/migrations/20210823001422_add_review_status_to_collections/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Collection` MODIFY `status` ENUM('DRAFT', 'REVIEW', 'PUBLISHED', 'ARCHIVED') DEFAULT 'DRAFT';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -175,6 +175,7 @@ enum ImageSizeCategory {
 
 enum CollectionStatus {
   DRAFT
+  REVIEW
   PUBLISHED
   ARCHIVED
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -97,6 +97,18 @@ async function main() {
     curationCategory: curationCategory1,
   });
   await createCollectionHelper(prisma, {
+    title: `Nina's second collection`,
+    author: nina,
+    curationCategory: curationCategory2,
+    status: CollectionStatus.REVIEW,
+  });
+  await createCollectionHelper(prisma, {
+    title: `Mathijs's' second collection`,
+    author: mathijs,
+    status: CollectionStatus.REVIEW,
+    publishedAt: new Date(),
+  });
+  await createCollectionHelper(prisma, {
     title: `Chelsea's' third collection`,
     author: chelsea,
     status: CollectionStatus.ARCHIVED,

--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -93,6 +93,7 @@ type Collection {
 
 enum CollectionStatus {
   DRAFT
+  REVIEW
   PUBLISHED
   ARCHIVED
 }

--- a/src/database/queries/Collection.integration.ts
+++ b/src/database/queries/Collection.integration.ts
@@ -144,7 +144,30 @@ describe('queries: Collection', () => {
       expect(collection.IABChildCategory).toBeTruthy();
     });
 
-    it("should not get a collection that isn't published", async () => {
+    it('should get a collection that is under review', async () => {
+      await createCollectionHelper(db, {
+        title: 'I am under review',
+        author,
+        status: CollectionStatus.REVIEW,
+        curationCategory,
+        IABParentCategory,
+        IABChildCategory,
+      });
+
+      const collection = await getCollectionBySlug(db, 'i-am-under-review');
+
+      expect(collection.title).toEqual('I am under review');
+
+      // ensure we are getting extra client data
+      expect(collection.authors).toBeTruthy();
+      expect(collection.stories).toBeTruthy();
+      expect(collection.curationCategory).toBeTruthy();
+      expect(collection.stories[0].authors).toBeTruthy();
+      expect(collection.IABParentCategory).toBeTruthy();
+      expect(collection.IABChildCategory).toBeTruthy();
+    });
+
+    it("should not get a collection that isn't published/under review", async () => {
       // the helper defaults to 'DRAFT' status
       await createCollectionHelper(db, {
         title: 'test me',

--- a/src/database/queries/Collection.ts
+++ b/src/database/queries/Collection.ts
@@ -59,7 +59,13 @@ export async function getCollectionBySlug(
   // slug is unique, but the generated type for `findUnique` here doesn't
   // include `status`, so using `findFirst` instead
   return db.collection.findFirst({
-    where: { slug, status: CollectionStatus.PUBLISHED },
+    where: {
+      slug,
+      // Allow not only published collections, but also collections under review
+      // so that the curators can preview a collection before it goes live
+      // officially.
+      status: { in: [CollectionStatus.REVIEW, CollectionStatus.PUBLISHED] },
+    },
     include: {
       authors: true,
       curationCategory: true,
@@ -110,6 +116,7 @@ export async function getCollectionsBySlugs(
  * @param db
  * @param page
  * @param perPage
+ * @param filters
  */
 export async function getPublishedCollections(
   db: PrismaClient,
@@ -142,6 +149,7 @@ export async function getPublishedCollections(
 
 /**
  * @param db
+ * @param filters
  */
 export async function countPublishedCollections(
   db: PrismaClient,


### PR DESCRIPTION
## Goal

Allow the curators to preview collections exactly as they are going to appear live without publishing them first. 

Tickets:

- https://getpocket.atlassian.net/browse/BACK-986

## Implementation Decisions

- Added a 'REVIEW' status for collections so that they can be previewed live. Added a Prisma migration to add this status to the database schema.

- Amended the 'getCollectionBySlug' query to include collections with the 'REVIEW' status in the results. Did not make any changes to 'getCollectionsBySlug' query.

- Updated integration tests.

- Added two more collections with the new 'REVIEW' status to the seed script.
