### PR TITLE
chore(tests): Add server integration tests for CollectionPartner

### DIFF
--- a/src/test/admin-server/mutations/CollectionPartner.server.integration.ts
+++ b/src/test/admin-server/mutations/CollectionPartner.server.integration.ts
@@ -1,0 +1,153 @@
+import * as faker from 'faker';
+import { db, server } from '../';
+import { clear as clearDb, createPartnerHelper } from '../../helpers';
+import {
+  CreateCollectionPartnerInput,
+  UpdateCollectionPartnerInput,
+  UpdateCollectionPartnerImageUrlInput,
+} from '../../../database/types';
+import {
+  CREATE_COLLECTION_PARTNER,
+  UPDATE_COLLECTION_PARTNER,
+  UPDATE_COLLECTION_PARTNER_IMAGE_URL,
+} from './mutations.gql';
+
+describe('mutations: CollectionPartner', () => {
+  const createData: CreateCollectionPartnerInput = {
+    name: faker.company.companyName(),
+    url: faker.internet.url(),
+    imageUrl: faker.image.imageUrl(),
+    blurb: faker.lorem.paragraphs(2),
+  };
+
+  beforeAll(async () => {
+    await server.start();
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+    await server.stop();
+  });
+
+  beforeEach(async () => {
+    await clearDb(db);
+  });
+
+  describe('createCollectionPartner mutation', () => {
+    it('creates a partner with all required variables supplied', async () => {
+      const {
+        data: { createCollectionPartner: partner },
+      } = await server.executeOperation({
+        query: CREATE_COLLECTION_PARTNER,
+        variables: createData,
+      });
+
+      expect(partner.externalId).toBeTruthy();
+      expect(partner.name).toEqual(createData.name);
+      expect(partner.url).toEqual(createData.url);
+      expect(partner.blurb).toEqual(createData.blurb);
+      expect(partner.imageUrl).toEqual(createData.imageUrl);
+    });
+
+    it('fails when no data is supplied', async () => {
+      // Attempt to create a partner with no input data...
+      const result = await server.executeOperation({
+        query: CREATE_COLLECTION_PARTNER,
+      });
+
+      // ...without success. There is no data
+      expect(result.data).toBeFalsy();
+
+      // And the server responds with an error about the first variable in the input
+      // that is missing
+      expect(result.errors[0].message).toMatch(
+        'Variable "$name" of required type "String!" was not provided.'
+      );
+    });
+  });
+
+  describe('updateCollectionPartner mutation', () => {
+    it('updates a partner', async () => {
+      const partner = await createPartnerHelper(
+        db,
+        faker.company.companyName()
+      );
+
+      const input: UpdateCollectionPartnerInput = {
+        externalId: partner.externalId,
+        name: 'Agatha Christie',
+        url: faker.internet.url(),
+        blurb: faker.lorem.paragraphs(2),
+        imageUrl: faker.image.imageUrl(),
+      };
+
+      const {
+        data: { updateCollectionPartner: updatedPartner },
+      } = await server.executeOperation({
+        query: UPDATE_COLLECTION_PARTNER,
+        variables: input,
+      });
+
+      expect(updatedPartner.name).toEqual(input.name);
+      expect(updatedPartner.url).toEqual(input.url);
+      expect(updatedPartner.blurb).toEqual(input.blurb);
+      expect(updatedPartner.imageUrl).toEqual(input.imageUrl);
+    });
+
+    it('does not update optional variables if they are not supplied', async () => {
+      const partner = await createPartnerHelper(db, 'Any Name');
+
+      const input: UpdateCollectionPartnerInput = {
+        externalId: partner.externalId,
+        name: 'Hands-free DevOps',
+        url: 'https://www.example.com/hands-free-devops',
+        blurb: faker.lorem.sentences(2),
+      };
+
+      const {
+        data: { updateCollectionPartner: updatedPartner },
+      } = await server.executeOperation({
+        query: UPDATE_COLLECTION_PARTNER,
+        variables: input,
+      });
+
+      // Expect the values supplied to be updated
+      expect(updatedPartner.name).toEqual(input.name);
+      expect(updatedPartner.url).toEqual(input.url);
+      expect(updatedPartner.blurb).toEqual(input.blurb);
+
+      // And the rest to stay as is
+      expect(updatedPartner.imageUrl).toEqual(partner.imageUrl);
+    });
+  });
+
+  describe('updateCollectionPartnerImageUrl', () => {
+    it("updates a partner's imageUrl and doesn't touch the other props", async () => {
+      const partner = await createPartnerHelper(
+        db,
+        faker.company.companyName()
+      );
+      const newImageUrl = 'https://www.example.com/ian-fleming.jpg';
+
+      const input: UpdateCollectionPartnerImageUrlInput = {
+        externalId: partner.externalId,
+        imageUrl: newImageUrl,
+      };
+
+      const {
+        data: { updateCollectionPartnerImageUrl: updatedPartner },
+      } = await server.executeOperation({
+        query: UPDATE_COLLECTION_PARTNER_IMAGE_URL,
+        variables: input,
+      });
+
+      // The image URL should be updated
+      expect(updatedPartner.imageUrl).toEqual(input.imageUrl);
+
+      // But the rest of the values should stay the same
+      expect(updatedPartner.name).toEqual(partner.name);
+      expect(updatedPartner.url).toEqual(partner.url);
+      expect(updatedPartner.blurb).toEqual(partner.blurb);
+    });
+  });
+});

--- a/src/test/admin-server/mutations/mutations.gql.ts
+++ b/src/test/admin-server/mutations/mutations.gql.ts
@@ -77,3 +77,65 @@ export const UPDATE_COLLECTION_AUTHOR_IMAGE_URL = gql`
     }
   }
 `;
+
+export const CREATE_COLLECTION_PARTNER = gql`
+  mutation createCollectionPartner(
+    $name: String!
+    $url: Url!
+    $blurb: Markdown!
+    $imageUrl: Url!
+  ) {
+    createCollectionPartner(
+      data: { name: $name, url: $url, blurb: $blurb, imageUrl: $imageUrl }
+    ) {
+      externalId
+      name
+      url
+      imageUrl
+      blurb
+    }
+  }
+`;
+
+export const UPDATE_COLLECTION_PARTNER = gql`
+  mutation updateCollectionPartner(
+    $externalId: String!
+    $name: String!
+    $url: Url!
+    $blurb: Markdown!
+    $imageUrl: Url
+  ) {
+    updateCollectionPartner(
+      data: {
+        externalId: $externalId
+        name: $name
+        url: $url
+        blurb: $blurb
+        imageUrl: $imageUrl
+      }
+    ) {
+      externalId
+      name
+      url
+      imageUrl
+      blurb
+    }
+  }
+`;
+
+export const UPDATE_COLLECTION_PARTNER_IMAGE_URL = gql`
+  mutation updateCollectionPartnerImageUrl(
+    $externalId: String!
+    $imageUrl: Url!
+  ) {
+    updateCollectionPartnerImageUrl(
+      data: { externalId: $externalId, imageUrl: $imageUrl }
+    ) {
+      externalId
+      name
+      url
+      imageUrl
+      blurb
+    }
+  }
+`;

--- a/src/test/admin-server/queries/CollectionPartner.server.integration.ts
+++ b/src/test/admin-server/queries/CollectionPartner.server.integration.ts
@@ -1,0 +1,158 @@
+import * as faker from 'faker';
+import { CollectionPartner } from '@prisma/client';
+import config from '../../../config';
+import { db, server } from '../';
+import { clear as clearDb, createPartnerHelper } from '../../helpers';
+import { CreateCollectionPartnerInput } from '../../../database/types';
+import { GET_COLLECTION_PARTNER, GET_COLLECTION_PARTNERS } from './queries.gql';
+
+describe('queries: CollectionPartner', () => {
+  beforeAll(async () => {
+    await clearDb(db);
+    await server.start();
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+    await server.stop();
+  });
+
+  describe('getCollectionPartners query', () => {
+    beforeAll(async () => {
+      // Create some partners
+      await createPartnerHelper(db, 'True Swag');
+      await createPartnerHelper(db, 'Free Range Voiceover');
+      await createPartnerHelper(db, 'Wearable Tools');
+      await createPartnerHelper(db, 'Your Choice Wearables');
+    });
+
+    it('should get partners in alphabetical order', async () => {
+      const {
+        data: { getCollectionPartners: data },
+      } = await server.executeOperation({
+        query: GET_COLLECTION_PARTNERS,
+        variables: {
+          page: 1,
+          perPage: 10,
+        },
+      });
+
+      expect(data.partners[0].name).toEqual('Free Range Voiceover');
+      expect(data.partners[1].name).toEqual('True Swag');
+      expect(data.partners[2].name).toEqual('Wearable Tools');
+      expect(data.partners[3].name).toEqual('Your Choice Wearables');
+    });
+
+    it('should get all available properties of collection partners', async () => {
+      const {
+        data: { getCollectionPartners: data },
+      } = await server.executeOperation({
+        query: GET_COLLECTION_PARTNERS,
+        variables: {
+          page: 1,
+          perPage: 1,
+        },
+      });
+
+      expect(data.partners[0].externalId).toBeTruthy();
+      expect(data.partners[0].name).toBeTruthy();
+      expect(data.partners[0].url).toBeTruthy();
+      expect(data.partners[0].imageUrl).toBeTruthy();
+      expect(data.partners[0].blurb).toBeTruthy();
+    });
+
+    it('should respect pagination', async () => {
+      const {
+        data: { getCollectionPartners: data },
+      } = await server.executeOperation({
+        query: GET_COLLECTION_PARTNERS,
+        variables: {
+          page: 2,
+          perPage: 2,
+        },
+      });
+
+      // We expect to get two results back
+      expect(data.partners.length).toEqual(2);
+
+      // Starting from page 2 of results, that is, from Wearable Tools
+      expect(data.partners[0].name).toEqual('Wearable Tools');
+      expect(data.partners[1].name).toEqual('Your Choice Wearables');
+    });
+
+    it('should return a pagination object', async () => {
+      const {
+        data: { getCollectionPartners: data },
+      } = await server.executeOperation({
+        query: GET_COLLECTION_PARTNERS,
+        variables: {
+          page: 2,
+          perPage: 3,
+        },
+      });
+
+      expect(data.pagination.currentPage).toEqual(2);
+      expect(data.pagination.totalPages).toEqual(2);
+      expect(data.pagination.totalResults).toEqual(4);
+      expect(data.pagination.perPage).toEqual(3);
+    });
+
+    it('should return data if no variables are supplied', async () => {
+      const {
+        data: { getCollectionPartners: data },
+      } = await server.executeOperation({
+        query: GET_COLLECTION_PARTNERS,
+      });
+
+      // Expect to get all our authors back
+      expect(data.partners.length).toEqual(4);
+
+      // Expect to see the app defaults for 'page' and 'perPage' variables
+      expect(data.pagination.currentPage).toEqual(1);
+      expect(data.pagination.perPage).toEqual(
+        config.app.pagination.partnersPerPage
+      );
+    });
+  });
+
+  describe('getCollectionPartner query', () => {
+    let partner: CollectionPartner;
+
+    beforeAll(async () => {
+      const name = 'Anna Burns';
+      const data: CreateCollectionPartnerInput = {
+        name,
+        url: faker.internet.url(),
+        imageUrl: faker.image.imageUrl(),
+        blurb: faker.lorem.paragraphs(2),
+      };
+      partner = await db.collectionPartner.create({ data });
+    });
+
+    it('should find a partner record by externalId and return all its properties', async () => {
+      const {
+        data: { getCollectionPartner: data },
+      } = await server.executeOperation({
+        query: GET_COLLECTION_PARTNER,
+        variables: { id: partner.externalId },
+      });
+
+      expect(data.externalId).toBeTruthy();
+      expect(data.name).toBeTruthy();
+      expect(data.url).toBeTruthy();
+      expect(data.imageUrl).toBeTruthy();
+      expect(data.blurb).toBeTruthy();
+    });
+
+    it('should fail on an invalid partner id', async () => {
+      const {
+        data: { getCollectionPartner: data },
+      } = await server.executeOperation({
+        query: GET_COLLECTION_PARTNER,
+        variables: { id: 'invalid-id' },
+      });
+
+      expect(data).toBeNull();
+    });
+  });
+});

--- a/src/test/admin-server/queries/queries.gql.ts
+++ b/src/test/admin-server/queries/queries.gql.ts
@@ -37,3 +37,35 @@ export const GET_COLLECTION_AUTHOR = gql`
     }
   }
 `;
+
+export const GET_COLLECTION_PARTNERS = gql`
+  query getCollectionPartners($page: Int, $perPage: Int) {
+    getCollectionPartners(page: $page, perPage: $perPage) {
+      partners {
+        externalId
+        name
+        url
+        imageUrl
+        blurb
+      }
+      pagination {
+        currentPage
+        totalPages
+        totalResults
+        perPage
+      }
+    }
+  }
+`;
+
+export const GET_COLLECTION_PARTNER = gql`
+  query getCollectionPartner($id: String!) {
+    getCollectionPartner(externalId: $id) {
+      externalId
+      name
+      url
+      imageUrl
+      blurb
+    }
+  }
+`;


### PR DESCRIPTION
## Goal

Chip away at server integration tests one entity at a time.

Added tests for queries and mutations that are used by Curation Tools Frontend.