### PR TITLE
[BACK-1061] Make sure no PagerDuty services are created for Dev environment

### DIFF
--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -33,4 +33,5 @@ export const config = {
     service: name,
     environment,
   },
+  isDev,
 };

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -132,7 +132,12 @@ class CollectionAPI extends TerraformStack {
    * Create PagerDuty service for alerts
    * @private
    */
-  private createPagerDuty() {
+  private createPagerDuty(): PocketPagerDuty | undefined {
+    if (config.isDev) {
+      // Don't create pagerduty services for a dev service.
+      return null;
+    }
+
     const incidentManagement = new DataTerraformRemoteState(
       this,
       'incident_management',


### PR DESCRIPTION
## Goal

Make sure we don't deploy alarms we never needed to have in the first place.

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1061


