### PR TITLE
fix(middleware): handle no find results in middleware

### DIFF
--- a/src/middleware/prisma.spec.ts
+++ b/src/middleware/prisma.spec.ts
@@ -128,6 +128,13 @@ describe('prisma middleware', () => {
 
       expect(res).toEqual(c);
     });
+
+    it('should return null if no collection was found', () => {
+      // if no collection was found, `null` will be passed
+      const res: any = PrismaMiddleware.injectItemIntoCollectionStories(null);
+
+      expect(res).toEqual(null);
+    });
   });
 
   describe('collectionStoryInjectItemMiddleware', () => {

--- a/src/middleware/prisma.ts
+++ b/src/middleware/prisma.ts
@@ -29,8 +29,13 @@ export type CollectionWithStoriesWithItem = Collection & {
 export function injectItemIntoCollectionStories(
   collection: CollectionWithStories
 ): CollectionWithStoriesWithItem {
-  // a collection may not include stories - if there are none, do nothing
-  if (!collection.stories) {
+  // a collection may not have been found - e.g. looking for a collection by
+  // an incorrect/no longer available slug.
+
+  // a collection may not include stories.
+
+  // in either case, just return the passed in value unmodified.
+  if (!collection?.stories) {
     return collection;
   }
 


### PR DESCRIPTION
## Goal

apollo studio is showing many 500 errors in collections around the `getCollectionBySlug` query. found an bug in the middleware (where we modify prisma results to link to parser items) that didn't handle empty results from any prisma-based `find` operation.

this should unblock us on implementing the `http5xxError` alarm.

not sure if this link to apollo studio works, but here's a try: https://studio.apollographql.com/graph/pocket-client-api/operations?query=78504a2206a698b9ecada3d5d0b9f15a816e667e&queryName=GetCollectionBySlug&tab=traces&trace=pocket-client-api~2021%3A09%3A15~4d778cfec62f01bba8e14242d7d5d85ed93e732b697628b164fca0403f782cdd&traceBucket&variant=current

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1055