### PR TITLE
fix(alarms): configure & enable http5xx alarm

### DIFF
--- a/.aws/package.json
+++ b/.aws/package.json
@@ -19,15 +19,15 @@
     "node": "=12"
   },
   "dependencies": {
-    "@cdktf/provider-aws": "1.0.129",
-    "@cdktf/provider-null": "0.1.131",
+    "@cdktf/provider-aws": "2.0.10",
+    "@cdktf/provider-null": "0.2.7",
     "@pocket/terraform-modules": "1.27.1",
-    "cdktf": "^0.4",
-    "constructs": "3.3.108"
+    "cdktf": "0.5.0",
+    "constructs": "3.3.147"
   },
   "devDependencies": {
-    "@types/node": "^12",
-    "cdktf-cli": "^0.4",
-    "typescript": "4.3.5"
+    "@types/node": "^12.20.25",
+    "cdktf-cli": "0.6.0",
+    "typescript": "4.4.3"
   }
 }

--- a/.aws/package.json
+++ b/.aws/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@cdktf/provider-aws": "1.0.129",
     "@cdktf/provider-null": "0.1.131",
-    "@pocket/terraform-modules": "1.23.0",
+    "@pocket/terraform-modules": "1.27.1",
     "cdktf": "^0.4",
     "constructs": "3.3.108"
   },

--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -17,6 +17,7 @@ const branch = isDev ? 'dev' : 'main';
 
 export const config = {
   name,
+  isDev,
   prefix: `${name}-${environment}`,
   circleCIPrefix: `/${name}/CircleCI/${environment}`,
   shortName: 'COLAPI',

--- a/.aws/src/config/index.ts
+++ b/.aws/src/config/index.ts
@@ -34,5 +34,4 @@ export const config = {
     service: name,
     environment,
   },
-  isDev,
 };

--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -306,22 +306,12 @@ class CollectionAPI extends TerraformStack {
         targetMaxCapacity: 10,
       },
       alarms: {
-        //TODO: When we start using this more we will change from non-critical to critical
-        http5xxError: {
-          threshold: 10,
-          evaluationPeriods: 2,
-          period: 600,
-          actions: [pagerDuty.snsNonCriticalAlarmTopic.arn],
-        },
-        httpLatency: {
-          evaluationPeriods: 2,
-          threshold: 500,
-          actions: [pagerDuty.snsNonCriticalAlarmTopic.arn],
-        },
-        httpRequestCount: {
-          threshold: 5000,
-          evaluationPeriods: 2,
-          actions: [pagerDuty.snsNonCriticalAlarmTopic.arn],
+        // alarms if >= 25% of responses are 5xx over 20 minutes
+        http5xxErrorPercentage: {
+          threshold: 25, // 25%
+          period: 300, // 5 minutes
+          evaluationPeriods: 4, // 20 minutes total
+          actions: config.isDev ? [] : [pagerDuty.snsCriticalAlarmTopic.arn],
         },
       },
     });


### PR DESCRIPTION
## Goal

configure & enable http5xx alarm

- add `isDev` config variable
- update to latest terraform-modules

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1057

## Implementation Decisions

going with our (now) standard 25% 5xx over 4 datapoints in 20 minutes config.