### PR TITLE
fix(getCollectionsBySlugs): return collections in requested order

### DIFF
--- a/src/dataLoaders/collectionLoader.spec.ts
+++ b/src/dataLoaders/collectionLoader.spec.ts
@@ -1,0 +1,81 @@
+import faker from 'faker';
+
+import { CollectionComplete } from '../database/types';
+import { sortCollectionsByGivenSlugs } from './collectionLoader';
+
+const quickCollectionCompleteMaker = (slug: string): CollectionComplete => {
+  return {
+    id: faker.datatype.number(),
+    externalId: faker.datatype.uuid(),
+    slug,
+    title: faker.random.words(5),
+    excerpt: null,
+    intro: null,
+    imageUrl: null,
+    language: 'en',
+    publishedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    curationCategoryId: null,
+    IABParentCategoryId: null,
+    IABChildCategoryId: null,
+    status: null,
+  };
+};
+
+// conjure some slugs
+const slugs = [
+  'lousy-smarch-weather',
+  'anything-slim',
+  'its-whisper-quiet',
+  'whoa-canyonero',
+  'you-dont-win-friends-with-salad',
+];
+
+describe('collectionLoader', () => {
+  describe('sortCollectionsByGivenSlugs', () => {
+    it('should sort the collections in the order of the given slugs', () => {
+      // conjure some collections matching the slugs, making sure they are in a
+      // different order than the slug array above
+      const collections: CollectionComplete[] = [
+        quickCollectionCompleteMaker('whoa-canyonero'),
+        quickCollectionCompleteMaker('lousy-smarch-weather'),
+        quickCollectionCompleteMaker('its-whisper-quiet'),
+        quickCollectionCompleteMaker('anything-slim'),
+        quickCollectionCompleteMaker('you-dont-win-friends-with-salad'),
+      ];
+
+      // they should now be sorted by the slug array
+      const sorted = sortCollectionsByGivenSlugs(slugs, collections);
+
+      for (let i = 0; i < slugs.length; i++) {
+        expect(sorted[i].slug).toEqual(slugs[i]);
+      }
+    });
+
+    it('should return undefined in the place of slug that was not found', () => {
+      // conjure some collections matching the slugs, making sure they are in a
+      // different order than the slug array above
+      const collections: CollectionComplete[] = [
+        quickCollectionCompleteMaker('whoa-canyonero'),
+        quickCollectionCompleteMaker('lousy-smarch-weather'),
+        quickCollectionCompleteMaker('anything-slim'),
+        quickCollectionCompleteMaker('you-dont-win-friends-with-salad'),
+      ];
+
+      // they should now be sorted by the slug array
+      const sorted = sortCollectionsByGivenSlugs(slugs, collections);
+
+      // even though one slug wasn't found the arrays should be of equal length
+      expect(sorted.length).toEqual(slugs.length);
+
+      for (let i = 0; i < slugs.length; i++) {
+        if (slugs[i] !== 'its-whisper-quiet') {
+          expect(sorted[i].slug).toEqual(slugs[i]);
+        } else {
+          expect(sorted[i]).toBeUndefined();
+        }
+      }
+    });
+  });
+});

--- a/src/dataLoaders/collectionLoader.ts
+++ b/src/dataLoaders/collectionLoader.ts
@@ -1,7 +1,43 @@
 import DataLoader from 'dataloader';
-import { getCollectionsBySlugs } from '../database/queries';
+
 import { PrismaClient, Collection } from '@prisma/client';
+
+import { CollectionComplete } from '../database/types';
+import { getCollectionsBySlugs } from '../database/queries';
 import { client } from '../database/client';
+
+/**
+ * helper function to ensure collections are returned in the order of the
+ * requested slugs
+ *
+ * localized/specialized version of this function from apollo-utils:
+ * https://github.com/Pocket/apollo-utils/blob/890862f2b66b8179e706a1522ce8d07da67a7c94/src/dataloader.ts#L109
+ *
+ * @param slugs an array of slug strings
+ * @param collections an array of CollectionComplete collections
+ * @returns
+ */
+export const sortCollectionsByGivenSlugs = (
+  slugs: string[],
+  collections: CollectionComplete[]
+): CollectionComplete[] => {
+  // create a map of slugs to collections
+  const slugToCollection = collections.reduce((acc, collection) => {
+    if (collection) {
+      return {
+        ...acc,
+        [collection.slug]: collection,
+      };
+    }
+
+    return acc;
+  }, {});
+
+  // sort the map in the order of the provided slugs
+  return slugs.map((slug) => {
+    return slugToCollection[slug];
+  });
+};
 
 /**
  * Grabs all collections from the database
@@ -12,7 +48,9 @@ export const batchFetchBySlugs = async (
 ): Promise<Collection[]> => {
   const db: PrismaClient = client();
 
-  return await getCollectionsBySlugs(db, slugs);
+  const collections = await getCollectionsBySlugs(db, slugs);
+
+  return sortCollectionsByGivenSlugs(slugs, collections);
 };
 
 /**


### PR DESCRIPTION
## Goal

ensures that collections requested by parser items are returned in the order requested.

this fixes a dataloader issue where client api would request multiple collections based on slug to satisfy parser item `collection` properties and those collections would be returned out of order, resulting in mismatched item data.

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1217

## Implementation Decisions

added a sorting algorithm before returning the collections, based on [a generic sorter in apollo utils](https://github.com/Pocket/apollo-utils/blob/890862f2b66b8179e706a1522ce8d07da67a7c94/src/dataloader.ts#L109).