### PR TITLE
feat(auth): add authentication to all admin queries

### DIFF
--- a/src/admin/context.ts
+++ b/src/admin/context.ts
@@ -3,15 +3,16 @@ import { S3 } from 'aws-sdk';
 import { Request } from 'express';
 import { client } from '../database/client';
 import s3service from '../aws/s3';
-import { COLLECTION_CURATOR_FULL } from '../shared/constants';
+import { COLLECTION_CURATOR_FULL, READONLY } from '../shared/constants';
 
 // Custom properties we get from Admin API for the authenticated user
 export interface AdminAPIUser {
   name: string;
   groups: string[];
   username: string;
-  // and one property we add for convenience as access to Collections is not granular
+  // access to collections is failry basic - you can either do everything or only read
   hasFullAccess: boolean;
+  canRead: boolean;
 }
 
 // Context interface
@@ -45,12 +46,14 @@ export class ContextManager implements IContext {
     const accessGroups = groups ? groups.split(',') : [];
 
     const hasFullAccess = accessGroups.includes(COLLECTION_CURATOR_FULL);
+    const hasReadOnly = accessGroups.includes(READONLY);
 
     return {
       name: this.config.request.headers.name as string,
       username: this.config.request.headers.username as string,
       groups: accessGroups,
       hasFullAccess,
+      canRead: hasReadOnly || hasFullAccess,
     };
   }
 }

--- a/src/admin/resolvers/mutations.ts
+++ b/src/admin/resolvers/mutations.ts
@@ -52,6 +52,7 @@ import {
   updateCollectionStoryImageUrl as dbUpdateCollectionStoryImageUrl,
 } from '../../database/mutations';
 import { uploadImage } from '../../aws/upload';
+import { ACCESS_DENIED_ERROR } from '../../shared/constants';
 import { IContext } from '../context';
 
 /**
@@ -71,9 +72,7 @@ export async function executeMutation<T, U>(
     const { db, authenticatedUser } = context;
 
     if (!authenticatedUser.hasFullAccess) {
-      throw new AuthenticationError(
-        `You do not have access to perform this action.`
-      );
+      throw new AuthenticationError(ACCESS_DENIED_ERROR);
     }
 
     const entity = await callback(db, data);
@@ -89,7 +88,6 @@ export async function executeMutation<T, U>(
 
     return entity;
   } catch (ex) {
-    console.log(ex);
     Sentry.captureException(ex);
     throw new Error(ex);
   }
@@ -105,7 +103,7 @@ export async function createCollectionAuthor(
   { data },
   context: IContext
 ): Promise<CollectionAuthor> {
-  return executeMutation<CreateCollectionAuthorInput, CollectionAuthor>(
+  return await executeMutation<CreateCollectionAuthorInput, CollectionAuthor>(
     context,
     data,
     dbCreateCollectionAuthor,
@@ -123,7 +121,7 @@ export async function updateCollectionAuthor(
   { data },
   context: IContext
 ): Promise<CollectionAuthor> {
-  return executeMutation<UpdateCollectionAuthorInput, CollectionAuthor>(
+  return await executeMutation<UpdateCollectionAuthorInput, CollectionAuthor>(
     context,
     data,
     dbUpdateCollectionAuthor,
@@ -141,7 +139,10 @@ export async function updateCollectionAuthorImageUrl(
   { data },
   context: IContext
 ): Promise<CollectionAuthor> {
-  return executeMutation<UpdateCollectionAuthorImageUrlInput, CollectionAuthor>(
+  return await executeMutation<
+    UpdateCollectionAuthorImageUrlInput,
+    CollectionAuthor
+  >(
     context,
     data,
     dbUpdateCollectionAuthorImageUrl,
@@ -159,7 +160,7 @@ export async function createCollection(
   { data },
   context: IContext
 ): Promise<Collection> {
-  return executeMutation<CreateCollectionInput, Collection>(
+  return await executeMutation<CreateCollectionInput, Collection>(
     context,
     data,
     dbCreateCollection,
@@ -213,7 +214,7 @@ export async function createCollectionPartner(
   { data },
   context: IContext
 ): Promise<CollectionPartner> {
-  return executeMutation<CreateCollectionPartnerInput, CollectionPartner>(
+  return await executeMutation<CreateCollectionPartnerInput, CollectionPartner>(
     context,
     data,
     dbCreateCollectionPartner,
@@ -231,7 +232,7 @@ export async function updateCollectionPartner(
   { data },
   context: IContext
 ): Promise<CollectionPartner> {
-  return executeMutation<UpdateCollectionPartnerInput, CollectionPartner>(
+  return await executeMutation<UpdateCollectionPartnerInput, CollectionPartner>(
     context,
     data,
     dbUpdateCollectionPartner,
@@ -249,7 +250,7 @@ export async function updateCollectionPartnerImageUrl(
   { data },
   context: IContext
 ): Promise<CollectionPartner> {
-  return executeMutation<
+  return await executeMutation<
     UpdateCollectionPartnerImageUrlInput,
     CollectionPartner
   >(
@@ -270,7 +271,7 @@ export async function createCollectionPartnerAssociation(
   { data },
   context: IContext
 ): Promise<CollectionPartnerAssociation> {
-  return executeMutation<
+  return await executeMutation<
     CreateCollectionPartnerAssociationInput,
     CollectionPartnerAssociation
   >(
@@ -291,7 +292,7 @@ export async function updateCollectionPartnerAssociation(
   { data },
   context: IContext
 ): Promise<CollectionPartnerAssociation> {
-  return executeMutation<
+  return await executeMutation<
     UpdateCollectionPartnerAssociationInput,
     CollectionPartnerAssociation
   >(
@@ -312,7 +313,7 @@ export async function updateCollectionPartnerAssociationImageUrl(
   { data },
   context: IContext
 ): Promise<CollectionPartnerAssociation> {
-  return executeMutation<
+  return await executeMutation<
     UpdateCollectionPartnerAssociationImageUrlInput,
     CollectionPartnerAssociation
   >(

--- a/src/admin/resolvers/queries.ts
+++ b/src/admin/resolvers/queries.ts
@@ -31,6 +31,7 @@ import {
   CollectionStory,
   CurationCategory,
 } from '@prisma/client';
+import { ACCESS_DENIED_ERROR } from '../../shared/constants';
 
 /**
  * @param parent
@@ -40,9 +41,13 @@ import {
 export async function getCollection(
   parent,
   { externalId },
-  { db }
+  { db, authenticatedUser }
 ): Promise<CollectionComplete> {
-  return dbGetCollection(db, externalId);
+  if (!authenticatedUser.canRead) {
+    throw new Error(ACCESS_DENIED_ERROR);
+  }
+
+  return await dbGetCollection(db, externalId);
 }
 
 /**
@@ -55,8 +60,12 @@ export async function getCollection(
 export async function searchCollections(
   parent,
   { filters, page = 1, perPage = config.app.pagination.collectionsPerPage },
-  { db }
+  { db, authenticatedUser }
 ): Promise<CollectionsResult> {
+  if (!authenticatedUser.canRead) {
+    throw new Error(ACCESS_DENIED_ERROR);
+  }
+
   if (!filters || (!filters.author && !filters.title && !filters.status)) {
     throw new Error(
       `At least one filter('author', 'title', 'status') is required`
@@ -81,8 +90,12 @@ export async function searchCollections(
 export async function getCollectionAuthors(
   parent,
   { page = 1, perPage = config.app.pagination.authorsPerPage },
-  { db }
+  { db, authenticatedUser }
 ): Promise<CollectionAuthorsResult> {
+  if (!authenticatedUser.canRead) {
+    throw new Error(ACCESS_DENIED_ERROR);
+  }
+
   const totalResults = await countAuthors(db);
   const authors = await getAuthors(db, page, perPage);
 
@@ -100,9 +113,13 @@ export async function getCollectionAuthors(
 export async function getCollectionAuthor(
   parent,
   { externalId },
-  { db }
+  { db, authenticatedUser }
 ): Promise<CollectionAuthor> {
-  return getAuthor(db, externalId);
+  if (!authenticatedUser.canRead) {
+    throw new Error(ACCESS_DENIED_ERROR);
+  }
+
+  return await getAuthor(db, externalId);
 }
 
 /**
@@ -113,11 +130,13 @@ export async function getCollectionAuthor(
 export async function getCollectionStory(
   parent,
   { externalId },
-  { db }
+  { db, authenticatedUser }
 ): Promise<CollectionStory> {
-  const collectionStory = await dbGetCollectionStory(db, externalId);
+  if (!authenticatedUser.canRead) {
+    throw new Error(ACCESS_DENIED_ERROR);
+  }
 
-  return collectionStory;
+  return await dbGetCollectionStory(db, externalId);
 }
 
 /**
@@ -127,21 +146,25 @@ export async function getCollectionStory(
 export async function getCurationCategories(
   parent,
   _,
-  { db }
+  { db, authenticatedUser }
 ): Promise<CurationCategory[]> {
-  const curationCategories = await dbGetCurationCategories(db);
+  if (!authenticatedUser.canRead) {
+    throw new Error(ACCESS_DENIED_ERROR);
+  }
 
-  return curationCategories;
+  return await dbGetCurationCategories(db);
 }
 
 export async function getIABCategories(
   parent,
   _,
-  { db }
+  { db, authenticatedUser }
 ): Promise<IABParentCategory[]> {
-  const IABCategories = dbGetIABCategories(db);
+  if (!authenticatedUser.canRead) {
+    throw new Error(ACCESS_DENIED_ERROR);
+  }
 
-  return IABCategories;
+  return await dbGetIABCategories(db);
 }
 
 /**
@@ -153,8 +176,12 @@ export async function getIABCategories(
 export async function getCollectionPartners(
   parent,
   { page = 1, perPage = config.app.pagination.partnersPerPage },
-  { db }
+  { db, authenticatedUser }
 ): Promise<CollectionPartnersResult> {
+  if (!authenticatedUser.canRead) {
+    throw new Error(ACCESS_DENIED_ERROR);
+  }
+
   const totalResults = await countPartners(db);
   const partners = await getPartners(db, page, perPage);
 
@@ -172,9 +199,13 @@ export async function getCollectionPartners(
 export async function getCollectionPartner(
   parent,
   { externalId },
-  { db }
+  { db, authenticatedUser }
 ): Promise<CollectionPartner> {
-  return getPartner(db, externalId);
+  if (!authenticatedUser.canRead) {
+    throw new Error(ACCESS_DENIED_ERROR);
+  }
+
+  return await getPartner(db, externalId);
 }
 
 /**
@@ -183,7 +214,11 @@ export async function getCollectionPartner(
  * @param _ (empty because this takes no params)
  * @param db
  */
-export function getLanguages(parent, _, { db }): any {
+export function getLanguages(parent, _, { db, authenticatedUser }): any {
+  if (!authenticatedUser.canRead) {
+    throw new Error(ACCESS_DENIED_ERROR);
+  }
+
   return config.app.languages.map((lang) => {
     return {
       code: lang,
@@ -199,9 +234,13 @@ export function getLanguages(parent, _, { db }): any {
 export async function getCollectionPartnerAssociation(
   parent,
   { externalId },
-  { db }
+  { db, authenticatedUser }
 ): Promise<CollectionPartnerAssociation> {
-  return dbGetCollectionPartnerAssociation(db, externalId);
+  if (!authenticatedUser.canRead) {
+    throw new Error(ACCESS_DENIED_ERROR);
+  }
+
+  return await dbGetCollectionPartnerAssociation(db, externalId);
 }
 
 /**
@@ -212,7 +251,11 @@ export async function getCollectionPartnerAssociation(
 export async function getCollectionPartnerAssociationForCollection(
   parent,
   { externalId },
-  { db }
+  { db, authenticatedUser }
 ): Promise<CollectionPartnerAssociation> {
-  return dbGetCollectionPartnerAssociationForCollection(db, externalId);
+  if (!authenticatedUser.canRead) {
+    throw new Error(ACCESS_DENIED_ERROR);
+  }
+
+  return await dbGetCollectionPartnerAssociationForCollection(db, externalId);
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,6 +1,8 @@
-// Only using one value from MozillaAccessGroup enum in Pocket Shared Data
+// Only using two values from MozillaAccessGroup enum in Pocket Shared Data
 export const COLLECTION_CURATOR_FULL =
   'mozilliansorg_pocket_collection_curator_full';
+
+export const READONLY = 'team_pocket';
 
 export const ACCESS_DENIED_ERROR =
   'You do not have access to perform this action.';

--- a/src/test/admin-server/queries/CurationCategory.server.integration.ts
+++ b/src/test/admin-server/queries/CurationCategory.server.integration.ts
@@ -1,9 +1,24 @@
 import { db, getServer } from '../';
-import { clear as clearDb, createCurationCategoryHelper } from '../../helpers';
+import {
+  clear as clearDb,
+  createCurationCategoryHelper,
+  getServerWithMockedHeaders,
+} from '../../helpers';
 import { GET_CURATION_CATEGORIES } from './queries.gql';
+import {
+  ACCESS_DENIED_ERROR,
+  COLLECTION_CURATOR_FULL,
+  READONLY,
+} from '../../../shared/constants';
 
 describe('queries: CurationCategory', () => {
-  const server = getServer();
+  const headers = {
+    name: 'Test User',
+    username: 'test.user@test.com',
+    groups: `group1,group2,${COLLECTION_CURATOR_FULL}`,
+  };
+
+  const server = getServerWithMockedHeaders(headers);
 
   beforeAll(async () => {
     await clearDb(db);
@@ -47,6 +62,69 @@ describe('queries: CurationCategory', () => {
       expect(data[0].externalId).toBeTruthy();
       expect(data[0].name).toBeTruthy();
       expect(data[0].slug).toBeTruthy();
+    });
+
+    it('should succeed if a user has only READONLY access', async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        // missing any collection/readoly group
+        groups: `group1,group2,${READONLY}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+
+      const result = await server.executeOperation({
+        query: GET_CURATION_CATEGORIES,
+      });
+
+      // we shouldn't have any errors
+      expect(result.errors).toBeFalsy();
+
+      // and data should exist
+      expect(result.data).toBeTruthy();
+
+      await server.stop();
+    });
+
+    it('should fail if user does not have access', async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        // missing any collection/readoly group
+        groups: `group1,group2`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+
+      const result = await server.executeOperation({
+        query: GET_CURATION_CATEGORIES,
+      });
+
+      // ...without success. There is no data
+      expect(result.data).toBeFalsy();
+
+      // And there is an access denied error
+      expect(result.errors[0].message).toMatch(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+
+    it('should fail if auth headers are empty', async () => {
+      const server = getServer();
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: GET_CURATION_CATEGORIES,
+      });
+
+      // ...without success. There is no data
+      expect(result.data).toBeFalsy();
+
+      // And there is an access denied error
+      expect(result.errors[0].message).toMatch(ACCESS_DENIED_ERROR);
+
+      await server.stop();
     });
   });
 });

--- a/src/test/admin-server/queries/Language.server.integration.ts
+++ b/src/test/admin-server/queries/Language.server.integration.ts
@@ -1,9 +1,21 @@
 import config from '../../../config';
-import { getServer } from '../';
+import { getServer } from '../index';
+import { getServerWithMockedHeaders } from '../../helpers';
 import { GET_LANGUAGES } from './queries.gql';
+import {
+  ACCESS_DENIED_ERROR,
+  COLLECTION_CURATOR_FULL,
+  READONLY,
+} from '../../../shared/constants';
 
 describe('queries: Language', () => {
-  const server = getServer();
+  const headers = {
+    name: 'Test User',
+    username: 'test.user@test.com',
+    groups: `group1,group2,${COLLECTION_CURATOR_FULL}`,
+  };
+
+  const server = getServerWithMockedHeaders(headers);
 
   beforeAll(async () => {
     await server.start();
@@ -26,6 +38,69 @@ describe('queries: Language', () => {
       data.forEach((language, index) => {
         expect(language.code).toEqual(config.app.languages[index]);
       });
+    });
+
+    it('should succeed if a user has only READONLY access', async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        // missing any collection/readoly group
+        groups: `group1,group2,${READONLY}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+
+      const result = await server.executeOperation({
+        query: GET_LANGUAGES,
+      });
+
+      // we shouldn't have any errors
+      expect(result.errors).toBeFalsy();
+
+      // and data should exist
+      expect(result.data).toBeTruthy();
+
+      await server.stop();
+    });
+
+    it('should fail if user does not have access', async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        // missing any collection/readoly group
+        groups: `group1,group2`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+
+      const result = await server.executeOperation({
+        query: GET_LANGUAGES,
+      });
+
+      // ...without success. There is no data
+      expect(result.data).toBeFalsy();
+
+      // And there is an access denied error
+      expect(result.errors[0].message).toMatch(ACCESS_DENIED_ERROR);
+
+      await server.stop();
+    });
+
+    it('should fail if auth headers are empty', async () => {
+      const server = getServer();
+      await server.start();
+
+      const result = await server.executeOperation({
+        query: GET_LANGUAGES,
+      });
+
+      // ...without success. There is no data
+      expect(result.data).toBeFalsy();
+
+      // And there is an access denied error
+      expect(result.errors[0].message).toMatch(ACCESS_DENIED_ERROR);
+
+      await server.stop();
     });
   });
 });


### PR DESCRIPTION
## Goal

add authorization to admin queries.

What changed:
- update `authenticatedUser` context
- add a bunch of missing `await`s
- update server integration tests for queries
- remove `console.log` from mutation helper

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1310

## Implementation Decisions

updating all existing server integration tests, but not feeling great about how many are missing - `Collection`, `CollectionStory`, and `CollectionPartnerAssociation`. do we feel comfortable merging this with those tests missing?

i am not totally comfortable building upon this level of tech debt - particularly given the number of `await` statements that were previously missing and added in this PR. if anything, i would want to ship this on a monday (or tuesday next week given the holiday) rather than push it out before a long weekend. will bring up prioritizing tests in slack.
