### PR TITLE
chore(tests): begin improving/standardizing integration tests

### DIFF
--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -1,4 +1,4 @@
-import { getCollectionBySlug, getCollections } from './queries';
+import { getCollectionBySlug, getCollections } from './queries/Collection';
 import { collection } from './item';
 import { collectionPartnershipFieldResolvers } from '../../shared/resolvers/types';
 

--- a/src/public/resolvers/queries/Collection.integration.ts
+++ b/src/public/resolvers/queries/Collection.integration.ts
@@ -1,0 +1,77 @@
+import { expect } from 'chai';
+import { db, getServer } from '../../../test/public-server';
+import {
+  clear as clearDb,
+  createAuthorHelper,
+  createCollectionHelper,
+  createCurationCategoryHelper,
+  createIABCategoryHelper,
+} from '../../../test/helpers';
+import { GET_COLLECTIONS } from './sample-queries.gql';
+import { CollectionStatus } from '@prisma/client';
+
+describe('public queries: Collection', () => {
+  const server = getServer();
+
+  let author;
+  let curationCategory;
+  let IABParentCategory;
+  let IABChildCategory;
+
+  beforeAll(async () => {
+    await clearDb(db);
+    await server.start();
+  });
+
+  beforeEach(async () => {
+    await clearDb(db);
+
+    // set up some default entities to use when creating collections in each test
+    // needs to be in `beforeEach` because we clear the db above - may refactor
+    // for better efficiency as more tests are added
+    author = await createAuthorHelper(db, 'walter');
+    curationCategory = await createCurationCategoryHelper(db, 'Business');
+    IABParentCategory = await createIABCategoryHelper(db, 'Entertainment');
+    IABChildCategory = await createIABCategoryHelper(
+      db,
+      'Bowling',
+      IABParentCategory
+    );
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+    await server.stop();
+  });
+
+  describe('getCollections', () => {
+    it('can get collections', async () => {
+      await createCollectionHelper(db, {
+        title: 'ways in which my back hurts',
+        author,
+        addStories: false,
+        curationCategory,
+        IABParentCategory,
+        IABChildCategory,
+        status: CollectionStatus.PUBLISHED,
+      });
+
+      await createCollectionHelper(db, {
+        title: 'best songs of 2006',
+        author,
+        addStories: false,
+        curationCategory,
+        IABParentCategory,
+        IABChildCategory,
+        status: CollectionStatus.PUBLISHED,
+      });
+
+      const result = await server.executeOperation({
+        query: GET_COLLECTIONS,
+      });
+
+      expect(result.errors).to.be.undefined;
+      expect(result.data?.getCollections?.collections.length).to.equal(2);
+    });
+  });
+});

--- a/src/public/resolvers/queries/Collection.ts
+++ b/src/public/resolvers/queries/Collection.ts
@@ -1,12 +1,12 @@
-import { CollectionComplete } from '../../database/types';
+import { CollectionComplete } from '../../../database/types';
 import {
   countPublishedCollections,
   getCollectionBySlug as dbGetCollectionBySlug,
   getPublishedCollections,
-} from '../../database/queries';
-import config from '../../config';
-import { CollectionsResult } from '../../typeDefs';
-import { getPagination } from '../../utils';
+} from '../../../database/queries';
+import config from '../../../config';
+import { CollectionsResult } from '../../../typeDefs';
+import { getPagination } from '../../../utils';
 
 /**
  * @param parent

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -1,0 +1,28 @@
+import { gql } from 'apollo-server-express';
+import { CollectionData } from '../../../shared/fragments.gql';
+
+/**
+ * Sample queries for Apollo Server integration tests as used in
+ * Curation Admin Tools Frontend
+ */
+
+export const GET_COLLECTIONS = gql`
+  query getCollections(
+    $page: Int
+    $perPage: Int
+    $filters: CollectionsFiltersInput
+  ) {
+    getCollections(page: $page, perPage: $perPage, filters: $filters) {
+      collections {
+        ...CollectionData
+      }
+      pagination {
+        currentPage
+        totalPages
+        totalResults
+        perPage
+      }
+    }
+  }
+  ${CollectionData}
+`;

--- a/src/shared/fragments.gql.ts
+++ b/src/shared/fragments.gql.ts
@@ -1,0 +1,96 @@
+import { gql } from 'apollo-server';
+
+export const CurationCategoryData = gql`
+  fragment CurationCategoryData on CurationCategory {
+    externalId
+    name
+    slug
+  }
+`;
+
+export const CollectionPartnershipData = gql`
+  fragment CollectionPartnershipData on CollectionPartnership {
+    externalId
+    type
+    name
+    url
+    imageUrl
+    blurb
+  }
+`;
+
+export const CollectionAuthorData = gql`
+  fragment CollectionAuthorData on CollectionAuthor {
+    externalId
+    name
+    slug
+    bio
+    imageUrl
+    active
+  }
+`;
+
+export const CollectionStoryAuthorData = gql`
+  fragment CollectionStoryAuthorData on CollectionStoryAuthor {
+    name
+    sortOrder
+  }
+`;
+
+export const CollectionStoryData = gql`
+  fragment CollectionStoryData on CollectionStory {
+    externalId
+    url
+    title
+    excerpt
+    imageUrl
+    authors {
+      ...CollectionStoryAuthorData
+    }
+    publisher
+    sortOrder
+    fromPartner
+  }
+  ${CollectionStoryAuthorData}
+`;
+
+export const IABCategoryData = gql`
+  fragment IABCategoryData on IABCategory {
+    externalId
+    name
+    slug
+  }
+`;
+
+export const CollectionData = gql`
+  fragment CollectionData on Collection {
+    externalId
+    slug
+    title
+    excerpt
+    status
+    curationCategory {
+      ...CurationCategoryData
+    }
+    intro
+    imageUrl
+    language
+    partnership {
+      ...CollectionPartnershipData
+    }
+    publishedAt
+    authors {
+      ...CollectionAuthorData
+    }
+    stories {
+      ...CollectionStoryData
+    }
+    IABParentCategory {
+      ...IABCategoryData
+    }
+    IABChildCategory {
+      ...IABCategoryData
+    }
+  }
+  ${CurationCategoryData}, ${CollectionPartnershipData}, ${CollectionAuthorData}, ${CollectionStoryData}, ${IABCategoryData}
+`;

--- a/src/test/public-server.ts
+++ b/src/test/public-server.ts
@@ -1,0 +1,31 @@
+import { ApolloServer } from 'apollo-server-express';
+import { buildSubgraphSchema } from '@apollo/federation';
+import {
+  ApolloServerPluginLandingPageDisabled,
+  ApolloServerPluginInlineTraceDisabled,
+  ApolloServerPluginUsageReportingDisabled,
+} from 'apollo-server-core';
+import { typeDefsPublic } from '../typeDefs';
+import { resolvers } from '../public/resolvers';
+import { client } from '../database/client';
+
+// Export this separately so that it can be used in Apollo integration tests
+export const db = client();
+
+export const getServer = () => {
+  return new ApolloServer({
+    schema: buildSubgraphSchema([{ typeDefs: typeDefsPublic, resolvers }]),
+    context: {
+      db: client(),
+    },
+    // Note the absence of the Sentry plugin - it emits
+    // "Cannot read property 'headers' of undefined" errors in tests.
+    // We get console.log statements that resolvers emit instead
+    // but the tests pass.
+    plugins: [
+      ApolloServerPluginLandingPageDisabled(),
+      ApolloServerPluginInlineTraceDisabled(),
+      ApolloServerPluginUsageReportingDisabled(),
+    ],
+  });
+};


### PR DESCRIPTION
## Goal

begin improving/standardizing integration tests

- add public test server
- add graphql fragments file
- move public query resolvers into a directory
- add a single basic integration test for public collection query

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1317
