### PR TITLE
chore(errors): implement apollo-utils error handling

### DIFF
--- a/src/admin/resolvers/mutations/Collection.integration.ts
+++ b/src/admin/resolvers/mutations/Collection.integration.ts
@@ -118,7 +118,7 @@ describe('mutations: Collection', () => {
       expect(data.data).not.to.exist;
       expect(data.errors.length).to.equal(1);
       expect(data.errors[0].message).to.equal(
-        'Error: A collection with the slug "walter-bowls" already exists'
+        'A collection with the slug "walter-bowls" already exists'
       );
     });
 
@@ -557,7 +557,7 @@ describe('mutations: Collection', () => {
       expect(data.data).not.to.exist;
       expect(data.errors).to.exist;
       expect(data.errors[0].message).to.equal(
-        'Error: A collection with the slug "first-iteration" already exists'
+        'A collection with the slug "first-iteration" already exists'
       );
     });
   });

--- a/src/admin/resolvers/mutations/CollectionAuthor.integration.ts
+++ b/src/admin/resolvers/mutations/CollectionAuthor.integration.ts
@@ -92,7 +92,7 @@ describe('mutations: CollectionAuthor', () => {
 
       expect(data.errors.length).to.equal(1);
       expect(data.errors[0].message).to.equal(
-        'Error: An author with the slug "his-dudeness" already exists'
+        'An author with the slug "his-dudeness" already exists'
       );
     });
   });
@@ -157,7 +157,7 @@ describe('mutations: CollectionAuthor', () => {
       // there's only one the dude
       expect(data.errors.length).to.equal(1);
       expect(data.errors[0].message).to.equal(
-        'Error: An author with the slug "the-dude" already exists'
+        'An author with the slug "the-dude" already exists'
       );
     });
   });

--- a/src/admin/resolvers/mutations/CollectionStory.integration.ts
+++ b/src/admin/resolvers/mutations/CollectionStory.integration.ts
@@ -161,7 +161,7 @@ describe('mutations: CollectionStory', () => {
 
       expect(data.errors.length).to.equal(1);
       expect(data.errors[0].message).to.equal(
-        `Error: A story with the url "${input.url}" already exists in this collection`
+        `A story with the url "${input.url}" already exists in this collection`
       );
     });
 
@@ -365,7 +365,7 @@ describe('mutations: CollectionStory', () => {
 
       expect(data.errors.length).to.equal(1);
       expect(data.errors[0].message).to.equal(
-        `Error: A story with the url "${input.url}" already exists in this collection`
+        `A story with the url "${input.url}" already exists in this collection`
       );
     });
 

--- a/src/admin/resolvers/queries/Collection.auth.integration.ts
+++ b/src/admin/resolvers/queries/Collection.auth.integration.ts
@@ -28,6 +28,7 @@ describe('auth: Collection', () => {
 
       expect(result.data.getCollection).not.to.exist;
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
 
     it('should fail if user does not have access', async () => {
@@ -49,6 +50,7 @@ describe('auth: Collection', () => {
 
       expect(result.data.getCollection).not.to.exist;
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
 
     it('should succeed if user has read only access', async () => {
@@ -67,7 +69,9 @@ describe('auth: Collection', () => {
         },
       });
 
-      expect(result.errors).not.to.exist;
+      // we should get a not found error instead of a forbidden error
+      expect(result.errors.length).to.equal(1);
+      expect(result.errors[0].extensions.code).to.equal('NOT_FOUND');
     });
 
     it('should succeed if user has full access', async () => {
@@ -86,7 +90,9 @@ describe('auth: Collection', () => {
         },
       });
 
-      expect(result.errors).not.to.exist;
+      // we should get a not found error instead of a forbidden error
+      expect(result.errors.length).to.equal(1);
+      expect(result.errors[0].extensions.code).to.equal('NOT_FOUND');
     });
   });
 
@@ -104,6 +110,7 @@ describe('auth: Collection', () => {
 
       expect(result.data).not.to.exist;
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
 
     it('should fail if user does not have access', async () => {
@@ -127,6 +134,7 @@ describe('auth: Collection', () => {
 
       expect(result.data).not.to.exist;
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
 
     it('should succeed if user has read only access', async () => {

--- a/src/admin/resolvers/queries/Collection.integration.ts
+++ b/src/admin/resolvers/queries/Collection.integration.ts
@@ -159,20 +159,25 @@ describe('admin queries: Collection', () => {
       expect(collection.partnership.type).to.equal(association.type);
     });
 
-    it('returns null if given an invalid externalId', async () => {
+    it('returns no data and a NOT_FOUND error if given an invalid externalId', async () => {
       const created = await createCollectionHelper(db, {
         title: 'test me',
         author,
       });
 
-      const { data } = await server.executeOperation({
+      const result = await server.executeOperation({
         query: GET_COLLECTION,
         variables: {
           externalId: created.externalId + 'type-o',
         },
       });
 
-      expect(data.getCollection).not.to.exist;
+      expect(result.errors.length).to.equal(1);
+      expect(result.errors[0].message).to.equal(
+        `Error - Not Found: ${created.externalId}type-o`
+      );
+      expect(result.errors[0].extensions.code).to.equal('NOT_FOUND');
+      expect(result.data.getCollection).not.to.exist;
     });
   });
 

--- a/src/admin/resolvers/queries/Collection.ts
+++ b/src/admin/resolvers/queries/Collection.ts
@@ -1,3 +1,5 @@
+import { ForbiddenError, UserInputError } from 'apollo-server-errors';
+import { NotFoundError } from '@pocket-tools/apollo-utils';
 import { CollectionComplete } from '../../../database/types';
 import { CollectionsResult } from '../../../typeDefs';
 import {
@@ -19,10 +21,16 @@ export async function getCollection(
   { db, authenticatedUser }
 ): Promise<CollectionComplete> {
   if (!authenticatedUser.canRead) {
-    throw new Error(ACCESS_DENIED_ERROR);
+    throw new ForbiddenError(ACCESS_DENIED_ERROR);
   }
 
-  return await dbGetCollection(db, externalId);
+  const collection = await dbGetCollection(db, externalId);
+
+  if (!collection) {
+    throw new NotFoundError(externalId);
+  }
+
+  return collection;
 }
 
 /**
@@ -38,11 +46,11 @@ export async function searchCollections(
   { db, authenticatedUser }
 ): Promise<CollectionsResult> {
   if (!authenticatedUser.canRead) {
-    throw new Error(ACCESS_DENIED_ERROR);
+    throw new ForbiddenError(ACCESS_DENIED_ERROR);
   }
 
   if (!filters || (!filters.author && !filters.title && !filters.status)) {
-    throw new Error(
+    throw new UserInputError(
       `At least one filter('author', 'title', 'status') is required`
     );
   }

--- a/src/admin/resolvers/queries/CollectionAuthor.auth.integration.ts
+++ b/src/admin/resolvers/queries/CollectionAuthor.auth.integration.ts
@@ -87,6 +87,7 @@ describe('auth: CollectionAuthor', () => {
 
       // And there is an access denied error
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
 
     it('should fail if auth headers are empty', async () => {
@@ -101,6 +102,7 @@ describe('auth: CollectionAuthor', () => {
 
       // And there is an access denied error
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
   });
 
@@ -161,6 +163,7 @@ describe('auth: CollectionAuthor', () => {
 
       // And there is an access denied error
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
 
     it('should fail if auth headers are empty', async () => {
@@ -176,6 +179,7 @@ describe('auth: CollectionAuthor', () => {
 
       // And there is an access denied error
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
   });
 });

--- a/src/admin/resolvers/queries/CollectionAuthor.integration.ts
+++ b/src/admin/resolvers/queries/CollectionAuthor.integration.ts
@@ -179,15 +179,18 @@ describe('queries: CollectionAuthor', () => {
       expect(data.active).to.exist;
     });
 
-    it('should fail on an invalid author id', async () => {
-      const {
-        data: { getCollectionAuthor: data },
-      } = await server.executeOperation({
+    it('should return NOT_FOUND on an invalid author id', async () => {
+      const result = await server.executeOperation({
         query: GET_COLLECTION_AUTHOR,
         variables: { id: 'invalid-id' },
       });
 
-      expect(data).not.to.exist;
+      expect(result.errors.length).to.equal(1);
+      expect(result.errors[0].message).to.equal(
+        `Error - Not Found: invalid-id`
+      );
+      expect(result.errors[0].extensions.code).to.equal('NOT_FOUND');
+      expect(result.data.getCollectionAuthor).not.to.exist;
     });
   });
 });

--- a/src/admin/resolvers/queries/CollectionPartner.auth.integration.ts
+++ b/src/admin/resolvers/queries/CollectionPartner.auth.integration.ts
@@ -72,6 +72,7 @@ describe('auth: CollectionPartner', () => {
 
       // And there is an access denied error
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
 
     it('should fail if auth headers are empty', async () => {
@@ -86,6 +87,7 @@ describe('auth: CollectionPartner', () => {
 
       // And there is an access denied error
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
   });
 
@@ -145,6 +147,7 @@ describe('auth: CollectionPartner', () => {
 
       // And there is an access denied error
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
 
     it('should fail if auth headers are empty', async () => {
@@ -160,6 +163,7 @@ describe('auth: CollectionPartner', () => {
 
       // And there is an access denied error
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
   });
 });

--- a/src/admin/resolvers/queries/CollectionPartner.integration.ts
+++ b/src/admin/resolvers/queries/CollectionPartner.integration.ts
@@ -161,15 +161,18 @@ describe('queries: CollectionPartner', () => {
       expect(data.blurb).to.exist;
     });
 
-    it('should fail on an invalid partner id', async () => {
-      const {
-        data: { getCollectionPartner: data },
-      } = await server.executeOperation({
+    it('should return NOT_FOUND on an invalid partner id', async () => {
+      const result = await server.executeOperation({
         query: GET_COLLECTION_PARTNER,
         variables: { id: 'invalid-id' },
       });
 
-      expect(data).not.to.exist;
+      expect(result.errors.length).to.equal(1);
+      expect(result.errors[0].message).to.equal(
+        `Error - Not Found: invalid-id`
+      );
+      expect(result.errors[0].extensions.code).to.equal('NOT_FOUND');
+      expect(result.data.getCollectionPartner).not.to.exist;
     });
   });
 
@@ -191,19 +194,22 @@ describe('queries: CollectionPartner', () => {
       expect(data.partner).to.exist;
     });
 
-    it('should return null on an invalid externalId', async () => {
+    it('should return NOT_FOUND on an invalid externalId', async () => {
       await createCollectionPartnerAssociationHelper(db, {
         type: CollectionPartnershipType.PARTNERED,
       });
 
-      const {
-        data: { getCollectionPartnerAssociation: data },
-      } = await server.executeOperation({
+      const result = await server.executeOperation({
         query: GET_COLLECTION_PARTNER_ASSOCIATION,
         variables: { externalId: 'invalid-id' },
       });
 
-      expect(data).not.to.exist;
+      expect(result.errors.length).to.equal(1);
+      expect(result.errors[0].message).to.equal(
+        `Error - Not Found: invalid-id`
+      );
+      expect(result.errors[0].extensions.code).to.equal('NOT_FOUND');
+      expect(result.data.getCollectionPartnerAssociation).not.to.exist;
     });
   });
 });

--- a/src/admin/resolvers/queries/CollectionStory.auth.integration.ts
+++ b/src/admin/resolvers/queries/CollectionStory.auth.integration.ts
@@ -27,6 +27,7 @@ describe('auth: CollectionStory', () => {
 
       expect(result.data.getCollectionStory).not.to.exist;
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
 
     it('should fail if user does not have access', async () => {
@@ -48,6 +49,7 @@ describe('auth: CollectionStory', () => {
 
       expect(result.data.getCollectionStory).not.to.exist;
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
 
     it('should succeed if user has read only access', async () => {
@@ -66,7 +68,9 @@ describe('auth: CollectionStory', () => {
         },
       });
 
-      expect(result.errors).not.to.exist;
+      // we should get a not found error instead of a forbidden error
+      expect(result.errors.length).to.equal(1);
+      expect(result.errors[0].extensions.code).to.equal('NOT_FOUND');
     });
 
     it('should succeed if user has full access', async () => {
@@ -85,7 +89,9 @@ describe('auth: CollectionStory', () => {
         },
       });
 
-      expect(result.errors).not.to.exist;
+      // we should get a not found error instead of a forbidden error
+      expect(result.errors.length).to.equal(1);
+      expect(result.errors[0].extensions.code).to.equal('NOT_FOUND');
     });
   });
 });

--- a/src/admin/resolvers/queries/CollectionStory.integration.ts
+++ b/src/admin/resolvers/queries/CollectionStory.integration.ts
@@ -84,15 +84,20 @@ describe('queries: CollectionStory', () => {
       );
     });
 
-    it('should fail to retrieve a collection story for an unknown externalID', async () => {
-      const { data } = await server.executeOperation({
+    it('should return NOT_FOUND for an unknown externalID', async () => {
+      const result = await server.executeOperation({
         query: GET_COLLECTION_STORY,
         variables: {
           externalId: story.externalId + 'typo',
         },
       });
 
-      expect(data.getCollectionStory).not.to.exist;
+      expect(result.errors.length).to.equal(1);
+      expect(result.errors[0].message).to.equal(
+        `Error - Not Found: ${story.externalId}typo`
+      );
+      expect(result.errors[0].extensions.code).to.equal('NOT_FOUND');
+      expect(result.data.getCollectionStory).not.to.exist;
     });
   });
 });

--- a/src/admin/resolvers/queries/CollectionStory.ts
+++ b/src/admin/resolvers/queries/CollectionStory.ts
@@ -1,6 +1,8 @@
+import { ForbiddenError } from 'apollo-server-errors';
 import { getCollectionStory as dbGetCollectionStory } from '../../../database/queries';
 import { CollectionStory } from '@prisma/client';
 import { ACCESS_DENIED_ERROR } from '../../../shared/constants';
+import { NotFoundError } from '@pocket-tools/apollo-utils';
 
 /**
  * @param parent
@@ -13,8 +15,14 @@ export async function getCollectionStory(
   { db, authenticatedUser }
 ): Promise<CollectionStory> {
   if (!authenticatedUser.canRead) {
-    throw new Error(ACCESS_DENIED_ERROR);
+    throw new ForbiddenError(ACCESS_DENIED_ERROR);
   }
 
-  return await dbGetCollectionStory(db, externalId);
+  const story = await dbGetCollectionStory(db, externalId);
+
+  if (!story) {
+    throw new NotFoundError(externalId);
+  }
+
+  return story;
 }

--- a/src/admin/resolvers/queries/CurationCategory.auth.integration.ts
+++ b/src/admin/resolvers/queries/CurationCategory.auth.integration.ts
@@ -66,6 +66,7 @@ describe('auth: CurationCategory', () => {
 
       // And there is an access denied error
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
 
     it('should fail if auth headers are empty', async () => {
@@ -80,6 +81,7 @@ describe('auth: CurationCategory', () => {
 
       // And there is an access denied error
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
   });
 });

--- a/src/admin/resolvers/queries/CurationCategory.ts
+++ b/src/admin/resolvers/queries/CurationCategory.ts
@@ -1,3 +1,4 @@
+import { ForbiddenError } from 'apollo-server-errors';
 import { getCurationCategories as dbGetCurationCategories } from '../../../database/queries';
 import { CurationCategory } from '@prisma/client';
 import { ACCESS_DENIED_ERROR } from '../../../shared/constants';
@@ -12,7 +13,7 @@ export async function getCurationCategories(
   { db, authenticatedUser }
 ): Promise<CurationCategory[]> {
   if (!authenticatedUser.canRead) {
-    throw new Error(ACCESS_DENIED_ERROR);
+    throw new ForbiddenError(ACCESS_DENIED_ERROR);
   }
 
   return await dbGetCurationCategories(db);

--- a/src/admin/resolvers/queries/IABCategory.auth.integration.ts
+++ b/src/admin/resolvers/queries/IABCategory.auth.integration.ts
@@ -77,6 +77,7 @@ describe('auth: IABCategory', () => {
 
       // And there is an access denied error
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
 
     it('should fail if auth headers are empty', async () => {
@@ -91,6 +92,7 @@ describe('auth: IABCategory', () => {
 
       // And there is an access denied error
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
   });
 });

--- a/src/admin/resolvers/queries/IABCategory.ts
+++ b/src/admin/resolvers/queries/IABCategory.ts
@@ -1,3 +1,4 @@
+import { ForbiddenError } from 'apollo-server-errors';
 import { IABParentCategory } from '../../../database/types';
 import { getIABCategories as dbGetIABCategories } from '../../../database/queries';
 import { ACCESS_DENIED_ERROR } from '../../../shared/constants';
@@ -8,7 +9,7 @@ export async function getIABCategories(
   { db, authenticatedUser }
 ): Promise<IABParentCategory[]> {
   if (!authenticatedUser.canRead) {
-    throw new Error(ACCESS_DENIED_ERROR);
+    throw new ForbiddenError(ACCESS_DENIED_ERROR);
   }
 
   return await dbGetIABCategories(db);

--- a/src/admin/resolvers/queries/Language.auth.integration.ts
+++ b/src/admin/resolvers/queries/Language.auth.integration.ts
@@ -60,6 +60,7 @@ describe('auth: Language', () => {
 
       // And there is an access denied error
       expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
     });
   });
 });

--- a/src/admin/resolvers/queries/Language.ts
+++ b/src/admin/resolvers/queries/Language.ts
@@ -1,3 +1,4 @@
+import { ForbiddenError } from 'apollo-server-errors';
 import { CollectionLanguage } from '../../../database/types';
 import { ACCESS_DENIED_ERROR } from '../../../shared/constants';
 
@@ -9,7 +10,7 @@ import { ACCESS_DENIED_ERROR } from '../../../shared/constants';
  */
 export function getLanguages(parent, _, { db, authenticatedUser }): any {
   if (!authenticatedUser.canRead) {
-    throw new Error(ACCESS_DENIED_ERROR);
+    throw new ForbiddenError(ACCESS_DENIED_ERROR);
   }
 
   return Object.values(CollectionLanguage);

--- a/src/admin/server.ts
+++ b/src/admin/server.ts
@@ -3,7 +3,7 @@ import { buildSubgraphSchema } from '@apollo/federation';
 import { Request } from 'express';
 import { typeDefsAdmin } from '../typeDefs';
 import { resolvers as adminResolvers } from './resolvers';
-import { sentryPlugin } from '@pocket-tools/apollo-utils';
+import { errorHandler, sentryPlugin } from '@pocket-tools/apollo-utils';
 import {
   ApolloServerPluginLandingPageDisabled,
   ApolloServerPluginLandingPageGraphQLPlayground,
@@ -36,6 +36,7 @@ export function getServer(contextFactory: ContextFactory): ApolloServer {
         : ApolloServerPluginLandingPageGraphQLPlayground(),
     ],
     context: ({ req }) => contextFactory(req),
+    formatError: errorHandler,
   });
 }
 

--- a/src/database/mutations/CollectionAuthor.ts
+++ b/src/database/mutations/CollectionAuthor.ts
@@ -1,3 +1,4 @@
+import { UserInputError } from 'apollo-server-errors';
 import { CollectionAuthor, PrismaClient } from '@prisma/client';
 import slugify from 'slugify';
 import config from '../../config';
@@ -23,7 +24,9 @@ export async function createCollectionAuthor(
   });
 
   if (slugExists) {
-    throw new Error(`An author with the slug "${data.slug}" already exists`);
+    throw new UserInputError(
+      `An author with the slug "${data.slug}" already exists`
+    );
   }
 
   return db.collectionAuthor.create({ data: { ...data } });
@@ -38,7 +41,7 @@ export async function updateCollectionAuthor(
   data: UpdateCollectionAuthorInput
 ): Promise<CollectionAuthor> {
   if (!data.externalId) {
-    throw new Error('externalId must be provided.');
+    throw new UserInputError('externalId must be provided.');
   }
 
   const slugExists = await db.collectionAuthor.count({
@@ -46,7 +49,9 @@ export async function updateCollectionAuthor(
   });
 
   if (slugExists) {
-    throw new Error(`An author with the slug "${data.slug}" already exists`);
+    throw new UserInputError(
+      `An author with the slug "${data.slug}" already exists`
+    );
   }
 
   return db.collectionAuthor.update({
@@ -64,7 +69,7 @@ export async function updateCollectionAuthorImageUrl(
   data: UpdateCollectionAuthorImageUrlInput
 ): Promise<CollectionAuthor> {
   if (!data.externalId) {
-    throw new Error('externalId must be provided.');
+    throw new UserInputError('externalId must be provided.');
   }
 
   return db.collectionAuthor.update({

--- a/src/database/mutations/CollectionPartner.ts
+++ b/src/database/mutations/CollectionPartner.ts
@@ -1,3 +1,4 @@
+import { UserInputError } from 'apollo-server-errors';
 import { CollectionPartner, PrismaClient } from '@prisma/client';
 
 import {
@@ -26,7 +27,7 @@ export async function updateCollectionPartner(
   data: UpdateCollectionPartnerInput
 ): Promise<CollectionPartner> {
   if (!data.externalId) {
-    throw new Error('externalId must be provided.');
+    throw new UserInputError('externalId must be provided.');
   }
 
   return db.collectionPartner.update({
@@ -44,7 +45,7 @@ export async function updateCollectionPartnerImageUrl(
   data: UpdateCollectionPartnerImageUrlInput
 ): Promise<CollectionPartner> {
   if (!data.externalId) {
-    throw new Error('externalId must be provided.');
+    throw new UserInputError('externalId must be provided.');
   }
 
   return db.collectionPartner.update({

--- a/src/database/mutations/CollectionPartnerAssociation.ts
+++ b/src/database/mutations/CollectionPartnerAssociation.ts
@@ -1,4 +1,4 @@
-import { UserInputError } from 'apollo-server';
+import { UserInputError } from 'apollo-server-errors';
 import { Prisma, PrismaClient } from '@prisma/client';
 
 import {
@@ -50,7 +50,7 @@ export async function updateCollectionPartnerAssociation(
   data: UpdateCollectionPartnerAssociationInput
 ): Promise<CollectionPartnerAssociation> {
   if (!data.externalId) {
-    throw new Error('externalId must be provided.');
+    throw new UserInputError('externalId must be provided.');
   }
 
   // this property doesn't exist on the Association type returned by this
@@ -81,7 +81,7 @@ export async function updateCollectionPartnerAssociationImageUrl(
   data: UpdateCollectionPartnerAssociationImageUrlInput
 ): Promise<CollectionPartnerAssociation> {
   if (!data.externalId) {
-    throw new Error('externalId must be provided.');
+    throw new UserInputError('externalId must be provided.');
   }
 
   return db.collectionPartnership.update({
@@ -102,7 +102,7 @@ export async function deleteCollectionPartnerAssociation(
   externalId: string
 ): Promise<CollectionPartnerAssociation> {
   if (!externalId) {
-    throw new Error('externalId must be provided.');
+    throw new UserInputError('externalId must be provided.');
   }
 
   // get the existing association for the internal id

--- a/src/database/mutations/CollectionStory.ts
+++ b/src/database/mutations/CollectionStory.ts
@@ -27,7 +27,7 @@ export async function createCollectionStory(
   });
 
   if (storyExists) {
-    throw new Error(
+    throw new UserInputError(
       `A story with the url "${data.url}" already exists in this collection`
     );
   }
@@ -73,7 +73,7 @@ export async function updateCollectionStory(
     });
 
     if (storyExists) {
-      throw new Error(
+      throw new UserInputError(
         `A story with the url "${data.url}" already exists in this collection`
       );
     }

--- a/src/database/queries/Collection.ts
+++ b/src/database/queries/Collection.ts
@@ -17,7 +17,7 @@ export async function getCollection(
   db: PrismaClient,
   externalId: string
 ): Promise<CollectionComplete> {
-  const collection = db.collection.findUnique({
+  return await db.collection.findUnique({
     where: { externalId },
     include: {
       authors: true,
@@ -35,8 +35,6 @@ export async function getCollection(
       },
     },
   });
-
-  return collection;
 }
 
 /**

--- a/src/public/resolvers/queries/Collection.integration.ts
+++ b/src/public/resolvers/queries/Collection.integration.ts
@@ -572,7 +572,7 @@ describe('public queries: Collection', () => {
       );
     });
 
-    it('should return no data for an invalid slug', async () => {
+    it('should return NOT_FOUND error for an invalid slug', async () => {
       const result = await server.executeOperation({
         query: GET_COLLECTION_BY_SLUG,
         variables: {
@@ -580,7 +580,12 @@ describe('public queries: Collection', () => {
         },
       });
 
-      expect(result.data?.getCollectionBySlug).to.be.null;
+      expect(result.data?.getCollectionBySlug).not.to.exist;
+      expect(result.errors.length).to.equal(1);
+      expect(result.errors[0].message).to.equal(
+        `Error - Not Found: this-is-just-good-timing`
+      );
+      expect(result.errors[0].extensions.code).to.equal('NOT_FOUND');
     });
   });
 });

--- a/src/public/resolvers/queries/Collection.ts
+++ b/src/public/resolvers/queries/Collection.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from '@pocket-tools/apollo-utils';
 import { CollectionComplete } from '../../../database/types';
 import {
   countPublishedCollections,
@@ -18,7 +19,13 @@ export async function getCollectionBySlug(
   { slug },
   { db }
 ): Promise<CollectionComplete> {
-  return dbGetCollectionBySlug(db, slug);
+  const collection = await dbGetCollectionBySlug(db, slug);
+
+  if (!collection) {
+    throw new NotFoundError(slug);
+  }
+
+  return collection;
 }
 
 /**

--- a/src/public/server.ts
+++ b/src/public/server.ts
@@ -4,7 +4,7 @@ import { typeDefsPublic } from '../typeDefs';
 import { resolvers as publicResolvers } from './resolvers';
 import responseCachePlugin from 'apollo-server-plugin-response-cache';
 import { GraphQLRequestContext } from 'apollo-server-types';
-import { sentryPlugin } from '@pocket-tools/apollo-utils';
+import { errorHandler, sentryPlugin } from '@pocket-tools/apollo-utils';
 import {
   ApolloServerPluginLandingPageDisabled,
   ApolloServerPluginLandingPageGraphQLPlayground,
@@ -39,4 +39,5 @@ export const server = new ApolloServer({
       collectionLoader,
     },
   },
+  formatError: errorHandler,
 });

--- a/src/test/admin-server/index.ts
+++ b/src/test/admin-server/index.ts
@@ -5,6 +5,7 @@ import {
   ApolloServerPluginLandingPageDisabled,
   ApolloServerPluginUsageReportingDisabled,
 } from 'apollo-server-core';
+import { errorHandler } from '@pocket-tools/apollo-utils';
 import { typeDefsAdmin } from '../../typeDefs';
 import { resolvers as adminResolvers } from '../../admin/resolvers';
 import { client } from '../../database/client';
@@ -43,5 +44,6 @@ export const getServer = (context?: ContextManager) => {
       ApolloServerPluginInlineTraceDisabled(),
       ApolloServerPluginUsageReportingDisabled(),
     ],
+    formatError: errorHandler,
   });
 };

--- a/src/test/public-server.ts
+++ b/src/test/public-server.ts
@@ -8,6 +8,7 @@ import {
 import { typeDefsPublic } from '../typeDefs';
 import { resolvers } from '../public/resolvers';
 import { client } from '../database/client';
+import { errorHandler } from '@pocket-tools/apollo-utils';
 
 // Export this separately so that it can be used in Apollo integration tests
 export const db = client();
@@ -27,5 +28,6 @@ export const getServer = () => {
       ApolloServerPluginInlineTraceDisabled(),
       ApolloServerPluginUsageReportingDisabled(),
     ],
+    formatError: errorHandler,
   });
 };


### PR DESCRIPTION
## Goal

implement our standard apollo-utils based error handling.

- add NOT_FOUND errors instead of returning null
- update some auth tests to check the expected error code

## Todos

- [x] check with client teams to verify response changes (`null` data to `NOT_FOUND` error) won't break anything

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1406
