### PR TITLE
fix(verbs): removing verb from the collectionBySlug query

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -14,8 +14,15 @@ type Query {
     perPage: Int
     filters: CollectionsFiltersInput
   ): CollectionsResult!
+
   """
   Retrieves a Collection by the given slug. The Collection must be published.
   """
   getCollectionBySlug(slug: String!): Collection
+    @deprecated(reason: "Use collectionBySlug instead")
+
+  """
+  Retrieves a {Collection} by the given slug. The {Collection} must be published.
+  """
+  collectionBySlug(slug: String!): Collection
 }

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -8,6 +8,7 @@ import { collectionPartnershipFieldResolvers } from '../../shared/resolvers/type
 export const resolvers = {
   Query: {
     getCollectionBySlug,
+    collectionBySlug: getCollectionBySlug,
     getCollections,
   },
   Item: {

--- a/src/public/resolvers/queries/Collection.integration.ts
+++ b/src/public/resolvers/queries/Collection.integration.ts
@@ -9,7 +9,11 @@ import {
   createIABCategoryHelper,
   sortCollectionStoryAuthors,
 } from '../../../test/helpers';
-import { GET_COLLECTIONS, GET_COLLECTION_BY_SLUG } from './sample-queries.gql';
+import {
+  COLLECTION_BY_SLUG,
+  GET_COLLECTIONS,
+  GET_COLLECTION_BY_SLUG,
+} from './sample-queries.gql';
 import {
   CollectionAuthor,
   CollectionStatus,
@@ -549,7 +553,7 @@ describe('public queries: Collection', () => {
       expect(data?.getCollectionBySlug).to.be.null;
     });
 
-    it('can get a collection by slug with story authors sorted correctly', async () => {
+    it('can get a collection by slug with getCollectionBySlug with story authors sorted correctly', async () => {
       await createCollectionHelper(db, {
         title: 'why february is sixty days long',
         author,
@@ -564,6 +568,29 @@ describe('public queries: Collection', () => {
       });
 
       const collection = data?.getCollectionBySlug;
+
+      // the default sort returned from prisma should match our expected
+      // manual sort
+      expect(collection.stories[0].authors).to.equal(
+        sortCollectionStoryAuthors(collection.stories[0].authors)
+      );
+    });
+
+    it('can get a collection by slug with collectionBySlug with story authors sorted correctly', async () => {
+      await createCollectionHelper(db, {
+        title: 'why february is sixty days long',
+        author,
+        status: CollectionStatus.PUBLISHED,
+      });
+
+      const { data } = await server.executeOperation({
+        query: COLLECTION_BY_SLUG,
+        variables: {
+          slug: 'why-february-is-sixty-days-long',
+        },
+      });
+
+      const collection = data?.collectionBySlug;
 
       // the default sort returned from prisma should match our expected
       // manual sort

--- a/src/public/resolvers/queries/sample-queries.gql.ts
+++ b/src/public/resolvers/queries/sample-queries.gql.ts
@@ -35,3 +35,12 @@ export const GET_COLLECTION_BY_SLUG = gql`
   }
   ${CollectionData}
 `;
+
+export const COLLECTION_BY_SLUG = gql`
+  query collectionBySlug($slug: String!) {
+    collectionBySlug(slug: $slug) {
+      ...CollectionData
+    }
+  }
+  ${CollectionData}
+`;


### PR DESCRIPTION
## Goal

Remove the verb from the `collectionBySlug` query

## Implementation Decisions

I specifically chose not to rename the getCollections query because I figured when we do that we should also make the new `collections` query use Cursor Based pagination.

I also did not touch the admin queries since the backend team only uses those and there's a lot to change there.