### PR TITLE
fix(CollectionLabel table): [BACK-1653] Refactor table to add collection and label associations

### DIFF
--- a/prisma/migrations/20221101154706_refactor_collection_label_table_add_associations/migration.sql
+++ b/prisma/migrations/20221101154706_refactor_collection_label_table_add_associations/migration.sql
@@ -1,0 +1,42 @@
+/*
+  Warnings:
+
+  - The primary key for the `CollectionLabel` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `collectionExternalId` on the `CollectionLabel` table. All the data in the column will be lost.
+  - You are about to drop the column `externalId` on the `CollectionLabel` table. All the data in the column will be lost.
+  - You are about to drop the column `id` on the `CollectionLabel` table. All the data in the column will be lost.
+  - You are about to drop the column `labelExternalId` on the `CollectionLabel` table. All the data in the column will be lost.
+  - Added the required column `collectionId` to the `CollectionLabel` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `createdBy` to the `CollectionLabel` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `labelId` to the `CollectionLabel` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropIndex
+DROP INDEX `CollectionLabel_collectionExternalId_idx` ON `CollectionLabel`;
+
+-- DropIndex
+DROP INDEX `CollectionLabel_externalId_idx` ON `CollectionLabel`;
+
+-- DropIndex
+DROP INDEX `CollectionLabel_externalId_key` ON `CollectionLabel`;
+
+-- DropIndex
+DROP INDEX `CollectionLabel_labelExternalId_idx` ON `CollectionLabel`;
+
+-- AlterTable
+ALTER TABLE `CollectionLabel` DROP PRIMARY KEY,
+    DROP COLUMN `collectionExternalId`,
+    DROP COLUMN `externalId`,
+    DROP COLUMN `id`,
+    DROP COLUMN `labelExternalId`,
+    ADD COLUMN `collectionId` INTEGER NOT NULL,
+    ADD COLUMN `createdAt` DATETIME(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0),
+    ADD COLUMN `createdBy` VARCHAR(255) NOT NULL,
+    ADD COLUMN `labelId` INTEGER NOT NULL,
+    ADD PRIMARY KEY (`labelId`, `collectionId`);
+
+-- AddForeignKey
+ALTER TABLE `CollectionLabel` ADD CONSTRAINT `CollectionLabel_labelId_fkey` FOREIGN KEY (`labelId`) REFERENCES `Label`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `CollectionLabel` ADD CONSTRAINT `CollectionLabel_collectionId_fkey` FOREIGN KEY (`collectionId`) REFERENCES `Collection`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20221102191937_refactor_label_table_remove_index_on_primary_key/migration.sql
+++ b/prisma/migrations/20221102191937_refactor_label_table_remove_index_on_primary_key/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX `Label_id_idx` ON `Label`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,31 +99,32 @@ model CollectionAuthor {
 }
 
 model Label {
-  id          Int       @id @default(autoincrement())
-  externalId  String    @default(uuid()) @db.VarChar(255)
-  name        String    @unique @db.VarChar(255)
-  createdAt   DateTime  @default(now()) @db.DateTime(0)
-  createdBy   String    @db.VarChar(255)
-  updatedAt   DateTime  @updatedAt
-  updatedBy   String?   @db.VarChar(255)
+  id          Int               @id @default(autoincrement())
+  externalId  String            @default(uuid()) @db.VarChar(255)
+  name        String            @unique @db.VarChar(255)
+  createdAt   DateTime          @default(now()) @db.DateTime(0)
+  createdBy   String            @db.VarChar(255)
+  updatedAt   DateTime          @updatedAt
+  updatedBy   String?           @db.VarChar(255)
+  collections CollectionLabel[]
+
 
   @@unique([externalId])
   @@index([id])
   @@index([name])
-
 }
 
 model CollectionLabel {
-  id                    Int @id @default(autoincrement())
-  externalId            String @default(uuid()) @db.VarChar(255)
-  labelExternalId       String @default(uuid()) @db.VarChar(255)
-  collectionExternalId  String @default(uuid()) @db.VarChar(255)
+  labelId      Int
+  collectionId Int
+  createdAt    DateTime @default(now()) @db.DateTime(0)
+  createdBy    String   @db.VarChar(255)
 
-  @@unique([externalId])
-  @@index([externalId])
-  @@index([labelExternalId])
-  @@index([collectionExternalId])
 
+  label      Label      @relation(fields: [labelId], references: [id])
+  collection Collection @relation(fields: [collectionId], references: [id])
+
+  @@id([labelId, collectionId])
 }
 
 model Collection {
@@ -148,6 +149,7 @@ model Collection {
   IABParentCategory   IABCategory?           @relation("CollectionIABParentCategory", fields: [IABParentCategoryId], references: [id])
   IABChildCategory    IABCategory?           @relation("CollectionIABChildCategory", fields: [IABChildCategoryId], references: [id])
   partnership         CollectionPartnership?
+  labels              CollectionLabel[]
 
   @@unique([externalId])
   @@index([slug])
@@ -155,12 +157,12 @@ model Collection {
 }
 
 model CurationCategory {
-  id         Int    @id @default(autoincrement())
-  externalId String @default(uuid()) @db.VarChar(255)
-  slug       String @unique @db.VarChar(300)
-  name       String @db.VarChar(255)
+  id          Int          @id @default(autoincrement())
+  externalId  String       @default(uuid()) @db.VarChar(255)
+  slug        String       @unique @db.VarChar(300)
+  name        String       @db.VarChar(255)
   collections Collection[]
-  
+
   @@unique([externalId])
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -110,7 +110,6 @@ model Label {
 
 
   @@unique([externalId])
-  @@index([id])
   @@index([name])
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,7 +3,10 @@ import {
   CollectionPartnershipType,
   PrismaClient,
 } from '@prisma/client';
-import { CollectionLanguage } from '../src/database/types';
+import {
+  CollectionLanguage,
+  CreateCollectionLabelInput,
+} from '../src/database/types';
 import {
   createAuthorHelper,
   createCollectionHelper,
@@ -51,12 +54,17 @@ async function main() {
     author: katerina,
     curationCategory: curationCategory1,
   });
+
+  // CollectionLabel table input data
+  const collectionLabelInputData: CreateCollectionLabelInput = {
+    collectionId: katerinaCollection.id,
+    labelId: katerinaLabel.id,
+    createdAt: new Date(),
+    createdBy: 'kchinnappan',
+  };
+
   // create collection - label association
-  await createCollectionLabelHelper(
-    prisma,
-    katerinaCollection.externalId,
-    katerinaLabel.externalId
-  );
+  await createCollectionLabelHelper(prisma, collectionLabelInputData);
 
   const curationCategory2 = await createCurationCategoryHelper(
     prisma,

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -38,8 +38,10 @@ export type CreateLabelInput = {
 };
 
 export type CreateCollectionLabelInput = {
-  collectionExternalId: string;
-  labelExternalId: string;
+  collectionId: number;
+  labelId: number;
+  createdAt: Date;
+  createdBy: string;
 };
 
 export type CreateCollectionInput = {

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -59,14 +59,8 @@ export async function createLabelHelper(
 // information required to create a Collection - Label association
 export async function createCollectionLabelHelper(
   prisma: PrismaClient,
-  collectionExternalId: string,
-  labelExternalId: string
+  data: CreateCollectionLabelInput
 ): Promise<CollectionLabel> {
-  const data: CreateCollectionLabelInput = {
-    collectionExternalId,
-    labelExternalId,
-  };
-
   return await prisma.collectionLabel.create({ data });
 }
 


### PR DESCRIPTION
## Goal

Follow up PR to https://github.com/Pocket/collection-api/pull/996.

We missed the two table associations to `Collection` and `Label` table. Also adding a composite key and a `createdAt` column. 

## Todos

- [x] Test in DEV

Tickets:

- BACK-1653