### PR TITLE
feat(labels): [BACK-1637] Admin schema - add a `labels` query and resolver

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -264,6 +264,11 @@ type Query {
   getCollectionPartnerAssociationForCollection(
     externalId: String!
   ): CollectionPartnerAssociation
+
+  """
+  Retrieves all available Labels
+  """
+  labels: [Label!]!
 }
 
 type Mutation {

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -35,6 +35,7 @@ import {
   updateCollectionStoryImageUrl,
 } from './mutations';
 import { collectionPartnershipFieldResolvers } from '../../shared/resolvers/types';
+import { labels } from './queries/Label';
 
 export const resolvers = {
   Mutation: {
@@ -71,6 +72,7 @@ export const resolvers = {
     getCurationCategories,
     getIABCategories,
     getLanguages,
+    labels,
   },
   CollectionPartnership: collectionPartnershipFieldResolvers,
 };

--- a/src/admin/resolvers/queries/Label.auth.integration.ts
+++ b/src/admin/resolvers/queries/Label.auth.integration.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import { db, getServer } from '../../../test/admin-server';
+import {
+  clear as clearDb,
+  createLabelHelper,
+  getServerWithMockedHeaders,
+} from '../../../test/helpers';
+import { LABELS } from './sample-queries.gql';
+import { ACCESS_DENIED_ERROR, READONLY } from '../../../shared/constants';
+
+describe('auth: Label', () => {
+  beforeAll(async () => {
+    await clearDb(db);
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  describe('labels query', () => {
+    beforeAll(async () => {
+      // Create some labels
+      await createLabelHelper(db, 'simon-le-bon');
+      await createLabelHelper(db, 'leonard-cohen');
+      await createLabelHelper(db, 'john-bon-jovi');
+    });
+
+    it('should succeed if a user has only READONLY access', async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        // missing any collection/readoly group
+        groups: `group1,group2,${READONLY}`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+
+      const result = await server.executeOperation({
+        query: LABELS,
+      });
+
+      // we shouldn't have any errors
+      expect(result.errors).not.to.exist;
+
+      // and data should exist
+      expect(result.data).to.exist;
+    });
+
+    it('should fail if user does not have access', async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        // missing any collection/readonly group
+        groups: `group1,group2`,
+      };
+
+      const server = getServerWithMockedHeaders(headers);
+
+      const result = await server.executeOperation({
+        query: LABELS,
+      });
+
+      // ...without success. There is no data
+      expect(result.data).not.to.exist;
+
+      // And there is an "access denied" error
+      expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
+    });
+
+    it('should fail if auth headers are empty', async () => {
+      const server = getServer();
+
+      const result = await server.executeOperation({
+        query: LABELS,
+      });
+
+      // ...without success. There is no data
+      expect(result.data).not.to.exist;
+
+      // And there is an "access denied" error
+      expect(result.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+      expect(result.errors[0].extensions.code).to.equal('FORBIDDEN');
+    });
+  });
+});

--- a/src/admin/resolvers/queries/Label.integration.ts
+++ b/src/admin/resolvers/queries/Label.integration.ts
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import { db } from '../../../test/admin-server';
+import {
+  clear as clearDb,
+  createLabelHelper,
+  getServerWithMockedHeaders,
+} from '../../../test/helpers';
+import { LABELS } from './sample-queries.gql';
+import { COLLECTION_CURATOR_FULL } from '../../../shared/constants';
+
+describe('queries: Label', () => {
+  const headers = {
+    name: 'Test User',
+    username: 'test.user@test.com',
+    groups: `group1,group2,${COLLECTION_CURATOR_FULL}`,
+  };
+
+  const server = getServerWithMockedHeaders(headers);
+
+  beforeAll(async () => {
+    await clearDb(db);
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  describe('labels query', () => {
+    beforeAll(async () => {
+      // Create some labels
+      await createLabelHelper(db, 'simon-le-bon');
+      await createLabelHelper(db, 'leonard-cohen');
+      await createLabelHelper(db, 'john-bon-jovi');
+    });
+
+    it('should get clabels in alphabetical order', async () => {
+      const {
+        data: { labels: data },
+      } = await server.executeOperation({
+        query: LABELS,
+      });
+
+      expect(data[0].name).to.equal('john-bon-jovi');
+      expect(data[1].name).to.equal('leonard-cohen');
+      expect(data[2].name).to.equal('simon-le-bon');
+    });
+
+    it('should get all publicly available properties of labels', async () => {
+      const {
+        data: { labels: data },
+      } = await server.executeOperation({
+        query: LABELS,
+      });
+
+      expect(data[0].externalId).to.exist;
+      expect(data[0].name).to.exist;
+    });
+  });
+});

--- a/src/admin/resolvers/queries/Label.ts
+++ b/src/admin/resolvers/queries/Label.ts
@@ -1,0 +1,25 @@
+import { ForbiddenError } from 'apollo-server-errors';
+import { ACCESS_DENIED_ERROR } from '../../../shared/constants';
+import { getLabels } from '../../../database/queries/Label';
+import { Label } from '../../../database/types';
+
+/**
+ * Retrieves all available labels.
+ *
+ * @param parent
+ * @param _
+ * @param db
+ * @param authenticatedUser
+ */
+export async function labels(
+  parent,
+  _,
+  { db, authenticatedUser }
+): Promise<Label[]> {
+  // Make sure the user has at least read-only access
+  if (!authenticatedUser.canRead) {
+    throw new ForbiddenError(ACCESS_DENIED_ERROR);
+  }
+
+  return await getLabels(db);
+}

--- a/src/admin/resolvers/queries/sample-queries.gql.ts
+++ b/src/admin/resolvers/queries/sample-queries.gql.ts
@@ -159,3 +159,12 @@ export const GET_LANGUAGES = gql`
     getLanguages
   }
 `;
+
+export const LABELS = gql`
+  query labels {
+    labels {
+      externalId
+      name
+    }
+  }
+`;

--- a/src/database/queries/Label.ts
+++ b/src/database/queries/Label.ts
@@ -1,0 +1,19 @@
+import { PrismaClient } from '@prisma/client';
+import { Label } from '../types';
+
+/**
+ * Retrieves all available labels from the datastore.
+ *
+ * @param db
+ */
+export async function getLabels(db: PrismaClient): Promise<Label[]> {
+  return db.label.findMany({
+    orderBy: { name: 'asc' },
+    select: {
+      // Until we do more with labels, we only need to retrieve
+      // the following two fields.
+      externalId: true,
+      name: true,
+    },
+  });
+}

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -215,3 +215,8 @@ export enum CollectionLanguage {
   EN = 'EN',
   DE = 'DE',
 }
+
+export type Label = {
+  externalId: string;
+  name: string;
+};

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -313,6 +313,10 @@ export async function clear(prisma: PrismaClient): Promise<void> {
   await prisma.collectionPartnership.deleteMany({});
   await prisma.collectionPartner.deleteMany({});
 
+  // labels
+  await prisma.collectionLabel.deleteMany({});
+  await prisma.label.deleteMany({});
+
   // collection stories
   await prisma.collectionStoryAuthor.deleteMany({});
   await prisma.collectionStory.deleteMany({});


### PR DESCRIPTION
## Goal

Add a new `labels` query so that the frontend can, in future, retrieve all available labels.

- Added a `labels` query to admin schema and a corresponding resolver.
- Added integration tests.
- Added authentication-related tests.

## Reference

Tickets:
- https://getpocket.atlassian.net/browse/BACK-1637