### PR TITLE
feat(labels): [BACK-1641, BACK-1650] Update `createCollection` mutation to incorporate labels

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,7 +108,6 @@ model Label {
   updatedBy   String?           @db.VarChar(255)
   collections CollectionLabel[]
 
-
   @@unique([externalId])
   @@index([name])
 }

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -53,6 +53,7 @@ input CreateCollectionInput {
   curationCategoryExternalId: String
   IABParentCategoryExternalId: String
   IABChildCategoryExternalId: String
+  labelExternalIds: [String]
 }
 
 input UpdateCollectionInput {

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -34,7 +34,10 @@ import {
   updateCollectionStorySortOrder,
   updateCollectionStoryImageUrl,
 } from './mutations';
-import { collectionPartnershipFieldResolvers } from '../../shared/resolvers/types';
+import {
+  collectionLabelsFieldResolvers,
+  collectionPartnershipFieldResolvers,
+} from '../../shared/resolvers/types';
 import { labels } from './queries/Label';
 
 export const resolvers = {
@@ -75,4 +78,5 @@ export const resolvers = {
     labels,
   },
   CollectionPartnership: collectionPartnershipFieldResolvers,
+  Label: collectionLabelsFieldResolvers,
 };

--- a/src/admin/resolvers/mutations.ts
+++ b/src/admin/resolvers/mutations.ts
@@ -5,7 +5,6 @@ import {
   CollectionStory,
   Image,
   ImageEntityType,
-  PrismaClient,
 } from '@prisma/client';
 import { AuthenticationError } from 'apollo-server-errors';
 import {
@@ -52,7 +51,7 @@ import {
 } from '../../database/mutations';
 import { uploadImage } from '../../aws/upload';
 import { ACCESS_DENIED_ERROR } from '../../shared/constants';
-import { IContext } from '../context';
+import { AdminAPIUser, IContext } from '../context';
 
 /**
  * Executes a mutation, catches exceptions and records to sentry and console
@@ -64,7 +63,7 @@ import { IContext } from '../context';
 export async function executeMutation<T, U>(
   context: IContext,
   data: T,
-  callback: (db: PrismaClient, data: T) => Promise<U>,
+  callback: (db, data: T, authenticatedUser?: AdminAPIUser) => Promise<U>,
   imageEntityType: ImageEntityType = undefined
 ): Promise<U> {
   const { db, authenticatedUser } = context;
@@ -73,7 +72,7 @@ export async function executeMutation<T, U>(
     throw new AuthenticationError(ACCESS_DENIED_ERROR);
   }
 
-  const entity = await callback(db, data);
+  const entity = await callback(db, data, authenticatedUser);
   // Associate the image with the entity if the image entity type is provided
   // and a record for the image exists
   if (imageEntityType) {

--- a/src/admin/resolvers/mutations/Collection.integration.ts
+++ b/src/admin/resolvers/mutations/Collection.integration.ts
@@ -11,6 +11,7 @@ import {
   createCurationCategoryHelper,
   createIABCategoryHelper,
   sortCollectionStoryAuthors,
+  createLabelHelper,
 } from '../../../test/helpers';
 import {
   CollectionLanguage,
@@ -30,6 +31,8 @@ describe('mutations: Collection', () => {
   let curationCategory;
   let IABParentCategory;
   let IABChildCategory;
+  let label1;
+  let label2;
   let minimumData;
 
   const headers = {
@@ -59,6 +62,9 @@ describe('mutations: Collection', () => {
       'Bowling',
       IABParentCategory
     );
+
+    label1 = await createLabelHelper(db, 'most-read');
+    label2 = await createLabelHelper(db, 'best-of-2022');
 
     // re-create the minimum data necessary to create a collection
     minimumData = {
@@ -177,6 +183,37 @@ describe('mutations: Collection', () => {
       expect(data.createCollection.IABChildCategory.externalId).to.equal(
         IABChildCategory.externalId
       );
+    });
+
+    it('should create a collection with a label', async () => {
+      const { data } = await server.executeOperation({
+        query: CREATE_COLLECTION,
+        variables: {
+          data: {
+            ...minimumData,
+            labelExternalIds: [label1.externalId],
+          },
+        },
+      });
+
+      expect(data.createCollection.labels[0].externalId).to.equal(
+        label1.externalId
+      );
+      expect(data.createCollection.labels[0].name).to.equal(label1.name);
+    });
+
+    it('should create a collection with multiple labels', async () => {
+      const { data } = await server.executeOperation({
+        query: CREATE_COLLECTION,
+        variables: {
+          data: {
+            ...minimumData,
+            labelExternalIds: [label1.externalId, label2.externalId],
+          },
+        },
+      });
+
+      expect(data.createCollection.labels).to.have.length(2);
     });
 
     it('should not connect an IAB child category if an IAB parent category is not set', async () => {

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -52,6 +52,7 @@ export type CreateCollectionInput = {
   IABParentCategoryExternalId?: string;
   imageUrl?: string;
   intro?: string;
+  labelExternalIds?: string[];
   language: CollectionLanguage;
   slug: string;
   status?: CollectionStatus;

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -1,6 +1,9 @@
 import { getCollectionBySlug, getCollections } from './queries/Collection';
 import { collection } from './item';
-import { collectionPartnershipFieldResolvers } from '../../shared/resolvers/types';
+import {
+  collectionLabelsFieldResolvers,
+  collectionPartnershipFieldResolvers,
+} from '../../shared/resolvers/types';
 
 /**
  * Resolvers
@@ -15,4 +18,5 @@ export const resolvers = {
     collection,
   },
   CollectionPartnership: collectionPartnershipFieldResolvers,
+  Label: collectionLabelsFieldResolvers,
 };

--- a/src/shared/fragments.gql.ts
+++ b/src/shared/fragments.gql.ts
@@ -116,6 +116,10 @@ export const CollectionData = gql`
     IABChildCategory {
       ...IABCategoryData
     }
+    labels {
+      externalId
+      name
+    }
   }
   ${CurationCategoryData}, ${CollectionPartnershipData}, ${CollectionAuthorData}, ${CollectionStoryData}, ${IABCategoryData}
 `;


### PR DESCRIPTION
## Goal

The goal of this PR is to be able to create a collection and assign one or more labels to it at the same time.

- Updated admin schema to add label external ids to mutation input.

- Updated DB-level resolver to add existing labels to a collection and retrieve them as part of mutation response.

- Added custom resolvers both for public and private schemas for the Label entity - there is no easier way to get the label data out when retrieved as part of Collection.

- Updated mutations to take in authenticated user from server context so that we can record who attached a label to a collection.

- Added integration tests.

## Reference

- https://getpocket.atlassian.net/browse/BACK-1641
- https://getpocket.atlassian.net/browse/BACK-1650