### PR TITLE
feat(labels): [BACK-1651, BACK-1639] Update `updateCollection` mutation to incorporate labels

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -69,6 +69,7 @@ input UpdateCollectionInput {
   curationCategoryExternalId: String
   IABParentCategoryExternalId: String
   IABChildCategoryExternalId: String
+  labelExternalIds: [String]
 }
 
 input UpdateCollectionImageUrlInput {

--- a/src/admin/context.ts
+++ b/src/admin/context.ts
@@ -10,7 +10,7 @@ export interface AdminAPIUser {
   name: string;
   groups: string[];
   username: string;
-  // access to collections is failry basic - you can either do everything or only read
+  // access to collections is fairly basic - you can either do everything or only read
   hasFullAccess: boolean;
   canRead: boolean;
 }

--- a/src/admin/resolvers/mutations/Collection.integration.ts
+++ b/src/admin/resolvers/mutations/Collection.integration.ts
@@ -470,7 +470,7 @@ describe('mutations: Collection', () => {
       // make sure there are no errors before running other expect() statements
       expect(data.errors).to.be.undefined;
 
-      // expect to see no labels whatsoever after the update
+      // expect to see two new labels
       expect(data.updateCollection.labels).to.have.length(2);
     });
 

--- a/src/admin/resolvers/mutations/Collection.integration.ts
+++ b/src/admin/resolvers/mutations/Collection.integration.ts
@@ -291,10 +291,19 @@ describe('mutations: Collection', () => {
         status: CollectionStatus.DRAFT,
       };
 
+      // We need to mock an API user to call a DB resolver directly in this test
+      const adminApiUser = {
+        name: 'Test User',
+        groups: ['any-group'],
+        username: 'test-user-ldap-something',
+        hasFullAccess: true,
+        canRead: true,
+      };
+
       // updatedAt is not a part of our API schema, but it's important to
       // test that this value is being updated, as it's used in sorting
       // results sent back to public clients
-      const updated = await updateCollection(db, input);
+      const updated = await updateCollection(db, input, adminApiUser);
 
       // should have updated the updatedAt field
       expect(updated.updatedAt.getTime()).to.be.greaterThan(
@@ -439,13 +448,131 @@ describe('mutations: Collection', () => {
       expect(data.updateCollection.IABChildCategory).not.to.exist;
     });
 
-    it('should return all associated data after updating - authors, curation category, IAB categories, stories, and story authors', async () => {
+    it('should add labels to a collection that has not had any previously', async () => {
+      const input: UpdateCollectionInput = {
+        authorExternalId: author.externalId,
+        externalId: initial.externalId,
+        language: CollectionLanguage.DE,
+        slug: initial.slug,
+        title: 'second iteration',
+        excerpt: 'once upon a time, the internet...',
+        status: CollectionStatus.DRAFT,
+        labelExternalIds: [label1.externalId, label2.externalId],
+      };
+
+      const { data } = await server.executeOperation({
+        query: UPDATE_COLLECTION,
+        variables: {
+          data: input,
+        },
+      });
+
+      // make sure there are no errors before running other expect() statements
+      expect(data.errors).to.be.undefined;
+
+      // expect to see no labels whatsoever after the update
+      expect(data.updateCollection.labels).to.have.length(2);
+    });
+
+    it('should remove existing labels on a collection if no new labels are provided', async () => {
+      // first, let's create a collection with a label
+      const { data: initial } = await server.executeOperation({
+        query: CREATE_COLLECTION,
+        variables: {
+          data: {
+            ...minimumData,
+            labelExternalIds: [label1.externalId, label2.externalId],
+          },
+        },
+      });
+
+      // provide a mock input that lacks any labels
+      const input: UpdateCollectionInput = {
+        authorExternalId: author.externalId,
+        externalId: initial.createCollection.externalId,
+        language: CollectionLanguage.DE,
+        slug: initial.createCollection.slug,
+        title: 'second iteration',
+        excerpt: 'once upon a time, the internet...',
+        status: CollectionStatus.DRAFT,
+      };
+
+      // run the update query on the server
+      const { data } = await server.executeOperation({
+        query: UPDATE_COLLECTION,
+        variables: {
+          data: input,
+        },
+      });
+
+      // make sure there are no errors before running other expect() statements
+      expect(data.errors).to.be.undefined;
+
+      // expect to see no labels whatsoever after the update
+      expect(data.updateCollection.labels).to.have.length(0);
+    });
+
+    it('should replace labels if a new set of labels was provided', async () => {
+      // first, let's create a collection with a label or two
+      const { data: initial } = await server.executeOperation({
+        query: CREATE_COLLECTION,
+        variables: {
+          data: {
+            ...minimumData,
+            labelExternalIds: [label1.externalId, label2.externalId],
+          },
+        },
+      });
+
+      // create two new labels
+      const label3 = await createLabelHelper(db, 'flying-is-overrated');
+      const label4 = await createLabelHelper(db, 'trains-are-the-best');
+
+      // provide a mock input with two different labels
+      const input: UpdateCollectionInput = {
+        authorExternalId: author.externalId,
+        externalId: initial.createCollection.externalId,
+        language: CollectionLanguage.DE,
+        labelExternalIds: [label3.externalId, label4.externalId],
+        slug: initial.createCollection.slug,
+        title: 'second iteration',
+        excerpt: 'once upon a time, the internet...',
+        status: CollectionStatus.DRAFT,
+      };
+
+      // run the update query on the server
+      const { data } = await server.executeOperation({
+        query: UPDATE_COLLECTION,
+        variables: {
+          data: input,
+        },
+      });
+
+      // make sure there are no errors before running other expect() statements
+      expect(data.errors).to.be.undefined;
+
+      // expect to see two labels
+      expect(data.updateCollection.labels).to.have.length(2);
+
+      // make sure it's the two new labels we provided in the update variables
+      expect(data.updateCollection.labels[0].name).to.equal(label3.name);
+      expect(data.updateCollection.labels[0].externalId).to.equal(
+        label3.externalId
+      );
+      expect(data.updateCollection.labels[1].name).to.equal(label4.name);
+      expect(data.updateCollection.labels[1].externalId).to.equal(
+        label4.externalId
+      );
+    });
+
+    it('should return all associated data after updating - authors, curation category, IAB categories, stories, labels and story authors', async () => {
       const input: UpdateCollectionInput = {
         IABChildCategoryExternalId: IABChildCategory.externalId,
         IABParentCategoryExternalId: IABParentCategory.externalId,
         authorExternalId: author.externalId,
         curationCategoryExternalId: curationCategory.externalId,
         externalId: initial.externalId,
+        labelExternalIds: [label1.externalId, label2.externalId],
         language: CollectionLanguage.DE,
         slug: initial.slug,
         title: 'second iteration',
@@ -473,6 +600,7 @@ describe('mutations: Collection', () => {
       expect(data.updateCollection.curationCategory).to.exist;
       expect(data.updateCollection.IABParentCategory).to.exist;
       expect(data.updateCollection.IABChildCategory).to.exist;
+      expect(data.updateCollection.labels).to.have.lengthOf(2);
     });
 
     it('should return story author sorted correctly', async () => {

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -68,6 +68,7 @@ export type UpdateCollectionInput = {
   IABParentCategoryExternalId?: string;
   imageUrl?: string;
   intro?: string;
+  labelExternalIds?: string[];
   language: CollectionLanguage;
   publishedAt?: Date;
   slug: string;

--- a/src/shared/resolvers/types.ts
+++ b/src/shared/resolvers/types.ts
@@ -68,11 +68,17 @@ export const collectionLabelsFieldResolvers = {
     _,
     { db }
   ): Promise<string> {
-    // TypeScript is unhappy while running integration tests without these checks in place
+    // TypeScript is unhappy while running integration tests without these specific
+    // checks in place - if('externalId' in parent) rather than if(parent.externalId).
+
+    // The 'externalId' prop is present only on the Label entity, so if that exists,
+    // we can just return the value as is
     if ('externalId' in parent) {
       return parent.externalId;
     }
 
+    // The 'labelId' is present only on the CollectionLabel entity, so we need to
+    // query the linked Label entity to get the external ID of the label
     if ('labelId' in parent) {
       const label = await getLabelById(db, parent.labelId);
       return label.externalId;
@@ -82,11 +88,17 @@ export const collectionLabelsFieldResolvers = {
   },
 
   async name(parent: Label | CollectionLabel, _, { db }): Promise<string> {
-    // TypeScript is unhappy while running integration tests without these checks in place
+    // TypeScript is unhappy while running integration tests without these specific
+    // checks in place - if('name' in parent) rather than if(parent.name).
+
+    // The 'name' prop is present only on the Label entity, so if that exists, we can just
+    // return the value as is
     if ('name' in parent) {
       return parent.name;
     }
 
+    // The 'labelId' is present only on the CollectionLabel entity, so we need to
+    // query the linked Label entity to get the name of the label
     if ('labelId' in parent) {
       const label = await getLabelById(db, parent.labelId);
       return label.name;


### PR DESCRIPTION
## Goal

Allow the curators to add to or remove labels from existing collections.

-  Updated admin schema to add label external ids to mutation input.
- Updated DB-level resolver to add or replace existing labels to a collection and retrieve them as part of mutation response.
- Added integration tests.
- Added more explanatory comments to custom resolvers for label fields introduced in #1000.

## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1651
- https://getpocket.atlassian.net/browse/BACK-1639