### PR TITLE
feat(labels): [BACK-1674] Populate the `Label` table

### DIFF
--- a/prisma/migrations/20221107035551_populate_label_table/migration.sql
+++ b/prisma/migrations/20221107035551_populate_label_table/migration.sql
@@ -1,0 +1,4 @@
+-- This is a fatto a mano migration to populate the Label table with the first, experimental label value.
+
+INSERT INTO Label (externalId, name, createdBy, updatedAt) VALUES ('794ad945-e385-4820-b350-799a40ea5868', 'region-east-africa', 'backend-product-squad', CURRENT_TIMESTAMP(0));
+

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -32,7 +32,7 @@ async function main() {
   //create Label with label name and creator
   const katerinaLabel = await createLabelHelper(
     prisma,
-    'region-east-africa',
+    'region-west-africa',
     'kchinnappan'
   );
 


### PR DESCRIPTION
## Goal

The goal of this PR is to have the first label data in the database for use on the frontend. 

- Added a Prisma migration to add the first label to the database.

- Updated the seed script to tweak one of the seed label values so that there is no conflict on running it with the migration already applied.


## Reference

Tickets:

- https://getpocket.atlassian.net/browse/BACK-1674
