### PR TITLE
fix(labels): [BACK-1685] Return labels for individual collection queries

### DIFF
--- a/schema-public.graphql
+++ b/schema-public.graphql
@@ -1,18 +1,18 @@
 input CollectionsFiltersInput {
   """
-  if not provided, or if an unsupported language is requested, defaults to `en`
+  If not provided, or if an unsupported language is requested, defaults to `en`
   """
   language: String
 
   """
-  if provided, will return collections that match at least one of the labels.
+  If provided, will return all collections that match at least one of the labels.
   """
   labels: [String]
 }
 
 type Query {
   """
-  Retrievs a paged set of published Collections.
+  Retrieves a paged set of published Collections.
   """
   getCollections(
     page: Int

--- a/src/admin/resolvers/queries/Collection.integration.ts
+++ b/src/admin/resolvers/queries/Collection.integration.ts
@@ -55,7 +55,7 @@ describe('admin queries: Collection', () => {
   });
 
   describe('getCollection', () => {
-    it('can get a collection with no stories by external id', async () => {
+    it('should get a collection with no stories', async () => {
       const created = await createCollectionHelper(db, {
         title: 'test me',
         author,
@@ -96,7 +96,7 @@ describe('admin queries: Collection', () => {
       expect(collection.labels.length).to.equal(0);
     });
 
-    it('can get a collection with stories with authors by external id', async () => {
+    it('should get a collection with stories with authors', async () => {
       const created = await createCollectionHelper(db, {
         title: 'test me',
         author,
@@ -116,7 +116,7 @@ describe('admin queries: Collection', () => {
       expect(collection.stories[0].authors[0]).not.to.be.undefined;
     });
 
-    it('can get a collection with story authors sorted correctly', async () => {
+    it('should get a collection with story authors sorted correctly', async () => {
       const created = await createCollectionHelper(db, {
         title: 'test me',
         author,
@@ -138,7 +138,7 @@ describe('admin queries: Collection', () => {
       );
     });
 
-    it('can get consolidated partnership information for a collection', async () => {
+    it('should get consolidated partnership information for a collection', async () => {
       const created = await createCollectionHelper(db, {
         title: 'test me',
         author,
@@ -163,7 +163,7 @@ describe('admin queries: Collection', () => {
       expect(collection.partnership.type).to.equal(association.type);
     });
 
-    it('should get a collection with labels when a collection with labels is requested via externalId', async () => {
+    it('should get a collection with labels', async () => {
       const testCollection = await createCollectionHelper(db, {
         title: 'test me',
         author,
@@ -203,7 +203,7 @@ describe('admin queries: Collection', () => {
       });
     });
 
-    it('returns no data and a NOT_FOUND error if given an invalid externalId', async () => {
+    it('should return no data and a NOT_FOUND error if given an invalid externalId', async () => {
       const created = await createCollectionHelper(db, {
         title: 'test me',
         author,
@@ -524,7 +524,7 @@ describe('admin queries: Collection', () => {
       expect(collections[0].title).to.equal('finishing my coffee');
     });
 
-    it('can get published collections with story authors sorted correctly', async () => {
+    it('should get published collections with story authors sorted correctly', async () => {
       const { data } = await server.executeOperation({
         query: SEARCH_COLLECTIONS,
         variables: {

--- a/src/admin/resolvers/queries/Collection.ts
+++ b/src/admin/resolvers/queries/Collection.ts
@@ -14,6 +14,7 @@ import { ACCESS_DENIED_ERROR } from '../../../shared/constants';
  * @param parent
  * @param externalId
  * @param db
+ * @param authenticatedUser
  */
 export async function getCollection(
   parent,
@@ -39,6 +40,7 @@ export async function getCollection(
  * @param page
  * @param perPage
  * @param db
+ * @param authenticatedUser
  */
 export async function searchCollections(
   parent,

--- a/src/database/queries/Collection.ts
+++ b/src/database/queries/Collection.ts
@@ -27,6 +27,7 @@ export async function getCollection(
       curationCategory: true,
       IABChildCategory: true,
       IABParentCategory: true,
+      labels: true,
       partnership: true,
       stories: {
         include: {
@@ -66,6 +67,7 @@ export async function getCollectionBySlug(
       curationCategory: true,
       IABParentCategory: true,
       IABChildCategory: true,
+      labels: true,
       partnership: true,
       stories: {
         include: {
@@ -94,6 +96,7 @@ export async function getCollectionsBySlugs(
       curationCategory: true,
       IABChildCategory: true,
       IABParentCategory: true,
+      labels: true,
       partnership: true,
       stories: {
         include: {


### PR DESCRIPTION
## Goal

Return label data with all collection-related queries; we overlooked some in the initial stage of updates to Collection API.


## Todos

- [x] Update DB resolvers to include `labels` with returned data
- [x] Add/update integration tests for affected queries, asserting that labels are returned: `getCollection` (admin-side query) - largely covered by @Herraj's commit - thank you!
- [x] Add/update integration tests for `getCollectionBySlug` query (public)
- [x] Add/update integration tests for `getCollectionsBySlugs` query (public)

## Reference

https://getpocket.atlassian.net/browse/BACK-1685