### PR TITLE
BACK-1638: createLabel mutation 

### DIFF
--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -378,4 +378,8 @@ type Mutation {
   deleteCollectionPartnerAssociation(
     externalId: String!
   ): CollectionPartnerAssociation!
+  """
+  Creates a Label.
+  """
+  createLabel(name: String!): Label!
 }

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -33,6 +33,7 @@ import {
   updateCollectionStory,
   updateCollectionStorySortOrder,
   updateCollectionStoryImageUrl,
+  createLabel,
 } from './mutations';
 import {
   collectionLabelsFieldResolvers,
@@ -61,6 +62,7 @@ export const resolvers = {
     collectionImageUpload,
     updateCollectionStorySortOrder,
     updateCollectionStoryImageUrl,
+    createLabel,
   },
   Query: {
     getCollection,

--- a/src/admin/resolvers/mutations.ts
+++ b/src/admin/resolvers/mutations.ts
@@ -5,6 +5,7 @@ import {
   CollectionStory,
   Image,
   ImageEntityType,
+  Label,
 } from '@prisma/client';
 import { AuthenticationError } from 'apollo-server-errors';
 import {
@@ -35,6 +36,7 @@ import {
   createCollectionPartnerAssociation as dbCreateCollectionPartnerAssociation,
   createCollectionStory as dbCreateCollectionStory,
   createImage,
+  createLabel as dbCreateLabel,
   deleteCollectionStory as dbDeleteCollectionStory,
   deleteCollectionPartnerAssociation as dbDeleteCollectionPartnerAssociation,
   updateCollectionAuthor as dbUpdateCollectionAuthor,
@@ -451,4 +453,12 @@ export async function collectionImageUpload(
   );
 
   return { url: upload.path };
+}
+
+export async function createLabel(
+  parent,
+  { name },
+  context: IContext
+): Promise<Label> {
+  return await executeMutation<string, Label>(context, name, dbCreateLabel);
 }

--- a/src/admin/resolvers/mutations/Label.integration.ts
+++ b/src/admin/resolvers/mutations/Label.integration.ts
@@ -1,0 +1,53 @@
+import { expect } from 'chai';
+import { db } from '../../../test/admin-server';
+import {
+  clear as clearDb,
+  createLabelHelper,
+  getServerWithMockedHeaders,
+} from '../../../test/helpers';
+import { CREATE_LABEL } from './sample-mutations.gql';
+import { COLLECTION_CURATOR_FULL } from '../../../shared/constants';
+
+describe('mutations: Label', () => {
+  const headers = {
+    name: 'Test User',
+    username: 'test.user@test.com',
+    groups: `group1,group2,${COLLECTION_CURATOR_FULL}`,
+  };
+
+  const server = getServerWithMockedHeaders(headers);
+
+  beforeAll(async () => {
+    await clearDb(db);
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  describe('createLabel', () => {
+    beforeAll(async () => {
+      // Create some labels
+      await createLabelHelper(db, 'simon-le-bon');
+    });
+
+    it('should create a new label', async () => {
+      const { data } = await server.executeOperation({
+        query: CREATE_LABEL,
+        variables: { name: 'katerina-ch-1' },
+      });
+      expect(data.createLabel.name).to.equal('katerina-ch-1');
+    });
+
+    it('should not create label that already exists', async () => {
+      const data = await server.executeOperation({
+        query: CREATE_LABEL,
+        variables: { name: 'simon-le-bon' },
+      });
+      expect(data.errors.length).to.equal(1);
+      expect(data.errors[0].message).to.equal(
+        `A label with the name "simon-le-bon" already exists`
+      );
+    });
+  });
+});

--- a/src/admin/resolvers/mutations/sample-mutations.gql.ts
+++ b/src/admin/resolvers/mutations/sample-mutations.gql.ts
@@ -182,3 +182,12 @@ export const DELETE_COLLECTION_STORY = gql`
   }
   ${CollectionStoryData}
 `;
+
+export const CREATE_LABEL = gql`
+  mutation createLabel($name: String!) {
+    createLabel(name: $name) {
+      name
+      externalId
+    }
+  }
+`;

--- a/src/admin/resolvers/queries/Label.integration.ts
+++ b/src/admin/resolvers/queries/Label.integration.ts
@@ -33,7 +33,7 @@ describe('queries: Label', () => {
       await createLabelHelper(db, 'john-bon-jovi');
     });
 
-    it('should get clabels in alphabetical order', async () => {
+    it('should get labels in alphabetical order', async () => {
       const {
         data: { labels: data },
       } = await server.executeOperation({

--- a/src/database/mutations.ts
+++ b/src/database/mutations.ts
@@ -10,6 +10,7 @@ export {
   updateCollection,
   updateCollectionImageUrl,
 } from './mutations/Collection';
+export { createLabel } from './mutations/Label';
 export {
   createCollectionPartner,
   updateCollectionPartner,

--- a/src/database/mutations/Label.ts
+++ b/src/database/mutations/Label.ts
@@ -1,0 +1,27 @@
+import { Label, PrismaClient } from '@prisma/client';
+import { AdminAPIUser } from '../../admin/context';
+import { UserInputError } from 'apollo-server-errors';
+
+/**
+ * @param db
+ * @param name
+ * @param authenticatedUser
+ */
+export async function createLabel(
+  db: PrismaClient,
+  name: string,
+  authenticatedUser: AdminAPIUser
+): Promise<Label> {
+  const labelNameCount = await db.label.count({
+    where: {
+      name: name,
+    },
+  });
+  if (labelNameCount > 0) {
+    throw new UserInputError(`A label with the name "${name}" already exists`);
+  }
+
+  return db.label.create({
+    data: { name: name, createdBy: authenticatedUser.username },
+  });
+}


### PR DESCRIPTION
## Goal

- Added database & resolver mutation to createLabel.
- Checking for label name uniqueness.
- Added appropriate integration tests.

Tickets:

- [https://getpocket.atlassian.net/browse/BACK-1638](https://getpocket.atlassian.net/browse/BACK-1638)