### PR TITLE
fix(ciTestStep): chore-add-generate-prisma-client-parameter-to-ci-test-step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  pocket: pocket/circleci-orbs@1.3.1
+  pocket: pocket/circleci-orbs@2.1.1
   backstage-entity-validator: roadiehq/backstage-entity-validator@0.4.2
 
 # Workflow shortcuts
@@ -70,8 +70,7 @@ jobs:
           command: cat schema-shared.graphql schema-admin.graphql > schema-admin-api.graphql
       - run:
           name: check service - client-api
-          command:
-            rover subgraph check pocket-client-api@current --schema ./schema-client-api.graphql --name=collection
+          command: rover subgraph check pocket-client-api@current --schema ./schema-client-api.graphql --name=collection
       - run:
           name: check service - admin-api
           # rover expects an APOLLO_KEY env var, which is set in circleci. however, there's a different key for admin-api,
@@ -224,6 +223,7 @@ workflows:
       - pocket/node_mocha_ts_test:
           <<: *not_main
           name: test_specs
+          generate_prisma_client: true
 
       - test_integrations:
           <<: *not_main


### PR DESCRIPTION
## Goal

Set the optional `generate_prisma_client` parameter to `true` for the `node_mocha_ts_test` ci step. 