### PR TITLE
 Collection resolve by slug reference

### DIFF
--- a/schema-shared.graphql
+++ b/schema-shared.graphql
@@ -83,7 +83,7 @@ type Label {
   name: String!
 }
 
-type Collection {
+type Collection @key(fields: "slug") {
   externalId: ID!
   slug: String!
   title: String!

--- a/src/public/resolvers/index.ts
+++ b/src/public/resolvers/index.ts
@@ -1,4 +1,8 @@
-import { getCollectionBySlug, getCollections } from './queries/Collection';
+import {
+  getCollectionBySlug,
+  getCollections,
+  resolveReference,
+} from './queries/Collection';
 import { collection } from './item';
 import {
   collectionLabelsFieldResolvers,
@@ -16,6 +20,9 @@ export const resolvers = {
   },
   Item: {
     collection,
+  },
+  Collection: {
+    __resolveReference: resolveReference,
   },
   CollectionPartnership: collectionPartnershipFieldResolvers,
   Label: collectionLabelsFieldResolvers,

--- a/src/public/resolvers/queries/Collection.ts
+++ b/src/public/resolvers/queries/Collection.ts
@@ -1,4 +1,4 @@
-import { NotFoundError } from '@pocket-tools/apollo-utils';
+import { NotFoundError, UserInputError } from '@pocket-tools/apollo-utils';
 import { CollectionComplete } from '../../../database/types';
 import {
   countPublishedCollections,
@@ -51,4 +51,18 @@ export async function getCollections(
     pagination: getPagination(totalResults, page, perPage),
     collections,
   };
+}
+
+export async function resolveReference({ slug }, { dataLoaders }) {
+  if (!slug) {
+    throw new UserInputError('Collection referenced without slug');
+  }
+
+  const collection = await dataLoaders.collectionLoader.load(slug);
+
+  if (!collection) {
+    throw new NotFoundError(slug);
+  }
+
+  return collection;
 }

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -76,6 +76,7 @@ export interface createCollectionHelperOptionalInput {
   addStories?: boolean;
   IABParentCategory?: IABCategory;
   IABChildCategory?: IABCategory;
+  slug?: string;
 }
 
 // the input for the `createCollectionHelper` function is a combo of the
@@ -127,11 +128,12 @@ export async function createCollectionHelper(
     addStories,
     IABParentCategory,
     IABChildCategory,
+    slug,
   } = mergedParams;
 
   const data: Prisma.CollectionCreateInput = {
     title,
-    slug: slugify(title, slugifyConfig),
+    slug: slug || slugify(title, slugifyConfig),
     excerpt: faker.lorem.sentences(2),
     intro: faker.lorem.paragraphs(2),
     status,


### PR DESCRIPTION
## Goal

Allow federated graphs to return collections by slug. See the [parent PR for more context](https://github.com/Pocket/curated-corpus-api/pull/829)
## Todos

- [x] Add resolve reference
- [x] Add tests

## Reference

- https://github.com/Pocket/curated-corpus-api/pull/829

## Implementation Decisions

Tried to follow all existing patterns.