### PR TITLE
INFRA-935: Add a limit to collection-label association

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -12,6 +12,7 @@ export default {
       authorsPerPage: 20,
       partnersPerPage: 20,
     },
+    collectionLabelLimit: 20,
     upload: {
       maxSize: 10000000, // in bytes => 10MB
       maxFiles: 10,

--- a/src/database/mutations/Collection.ts
+++ b/src/database/mutations/Collection.ts
@@ -8,6 +8,7 @@ import {
   UpdateCollectionImageUrlInput,
   UpdateCollectionInput,
 } from '../types';
+import { checkCollectionLabelLimit } from '../utils';
 import { NotFoundError } from '@pocket-tools/apollo-utils';
 import { AdminAPIUser } from '../../admin/context';
 
@@ -82,7 +83,11 @@ export async function createCollection(
   }
 
   // if a collection has any labels, set up a connection to labels, too
+  // first check if collection-label limit is not exceeded
   if (labelExternalIds) {
+    // if exceeded, throw error
+    checkCollectionLabelLimit(labelExternalIds);
+
     const connectIds = [];
 
     for (const id of labelExternalIds) {
@@ -256,7 +261,11 @@ export async function updateCollection(
   });
 
   // If a collection has any labels, set up a connection to labels, too
+  // first check if collection-label limit is not exceeded
   if (labelExternalIds) {
+    // if exceeded, throw error
+    checkCollectionLabelLimit(labelExternalIds);
+
     const connectIds = [];
 
     for (const id of labelExternalIds) {

--- a/src/database/utils.ts
+++ b/src/database/utils.ts
@@ -1,4 +1,5 @@
 import { CollectionStatus, Prisma } from '@prisma/client';
+import { UserInputError } from '@pocket-tools/apollo-utils';
 import {
   CollectionsFilters,
   CollectionLanguage,
@@ -68,4 +69,12 @@ export function buildSearchCollectionsWhereClause(
   }
 
   return where;
+}
+
+export function checkCollectionLabelLimit(labelExternalIds: string[]) {
+  if (labelExternalIds.length > config.app.collectionLabelLimit) {
+    throw new UserInputError(
+      `Too many labels provided: ${config.app.collectionLabelLimit} allowed, ${labelExternalIds.length} provided.`
+    );
+  }
 }


### PR DESCRIPTION
## Goal

Currently, a collection can have a max of 20 labels. Add this limit to `createCollection` and `updateCollection` mutations.

## Todos

* [ ] After review, push to dev before merge.

## Tickets

* [https://getpocket.atlassian.net/browse/INFRA-935](https://getpocket.atlassian.net/browse/INFRA-935)

## Implementation Decisions

* Added a `collectionLabelLimit` config variable to `src/config` to store the collection-label association limit which can be easily updated in the future if needed.
* Added a `checkCollectionLabelLimit(labelExternalIds: string[])` to `src/database/utils.ts` utility function to check the limit.