### PR TITLE
INFRA-936: add updateLabel mutation and tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ Documentation here:
 
 - Link to docs
 
-Tickets:
+## Tickets
 
 - Link to JIRA tickets
 

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -387,7 +387,7 @@ type Mutation {
   """
   createLabel(name: String!): Label!
   """
-  Updates a Label.
+  Updates a Label that is not assigned to any Collection yet.
   """
   updateLabel(data: UpdateLabelInput!): Label!
 }

--- a/schema-admin.graphql
+++ b/schema-admin.graphql
@@ -57,6 +57,10 @@ input CreateCollectionInput {
   labelExternalIds: [String]
 }
 
+input UpdateLabelInput {
+  externalId: String
+  name: String!
+}
 input UpdateCollectionInput {
   externalId: String
   slug: String!
@@ -382,4 +386,8 @@ type Mutation {
   Creates a Label.
   """
   createLabel(name: String!): Label!
+  """
+  Updates a Label.
+  """
+  updateLabel(data: UpdateLabelInput!): Label!
 }

--- a/src/admin/resolvers/index.ts
+++ b/src/admin/resolvers/index.ts
@@ -34,6 +34,7 @@ import {
   updateCollectionStorySortOrder,
   updateCollectionStoryImageUrl,
   createLabel,
+  updateLabel,
 } from './mutations';
 import {
   collectionLabelsFieldResolvers,
@@ -63,6 +64,7 @@ export const resolvers = {
     updateCollectionStorySortOrder,
     updateCollectionStoryImageUrl,
     createLabel,
+    updateLabel,
   },
   Query: {
     getCollection,

--- a/src/admin/resolvers/mutations.ts
+++ b/src/admin/resolvers/mutations.ts
@@ -27,6 +27,7 @@ import {
   UpdateCollectionStoryImageUrlInput,
   UpdateCollectionStoryInput,
   UpdateCollectionStorySortOrderInput,
+  UpdateLabelInput,
 } from '../../database/types';
 import {
   associateImageWithEntity,
@@ -37,6 +38,7 @@ import {
   createCollectionStory as dbCreateCollectionStory,
   createImage,
   createLabel as dbCreateLabel,
+  updateLabel as dbUpdateLabel,
   deleteCollectionStory as dbDeleteCollectionStory,
   deleteCollectionPartnerAssociation as dbDeleteCollectionPartnerAssociation,
   updateCollectionAuthor as dbUpdateCollectionAuthor,
@@ -461,4 +463,21 @@ export async function createLabel(
   context: IAdminContext
 ): Promise<Label> {
   return await executeMutation<string, Label>(context, name, dbCreateLabel);
+}
+
+/**
+ * @param parent
+ * @param data
+ * @param context
+ */
+export async function updateLabel(
+  parent,
+  { data },
+  context: IAdminContext
+): Promise<Label> {
+  return await executeMutation<UpdateLabelInput, Label>(
+    context,
+    data,
+    dbUpdateLabel
+  );
 }

--- a/src/admin/resolvers/mutations/Label.auth.integration.ts
+++ b/src/admin/resolvers/mutations/Label.auth.integration.ts
@@ -1,0 +1,188 @@
+import { expect } from 'chai';
+import { print } from 'graphql';
+import request from 'supertest';
+import { ApolloServer } from '@apollo/server';
+import { PrismaClient } from '@prisma/client';
+import { client } from '../../../database/client';
+
+import { clear as clearDb, createLabelHelper } from '../../../test/helpers';
+import { CREATE_LABEL, UPDATE_LABEL } from './sample-mutations.gql';
+import {
+  ACCESS_DENIED_ERROR,
+  READONLY,
+  FULLACCESS,
+} from '../../../shared/constants';
+import { startServer } from '../../../express';
+import { IAdminContext } from '../../context';
+import { UpdateLabelInput } from '../../../database/types';
+
+describe('auth: Label', () => {
+  let app: Express.Application;
+  let server: ApolloServer<IAdminContext>;
+  let graphQLUrl: string;
+  let db: PrismaClient;
+  let label1;
+
+  beforeAll(async () => {
+    // port 0 tells express to dynamically assign an available port
+    ({ app, adminServer: server, adminUrl: graphQLUrl } = await startServer(0));
+    db = client();
+    await clearDb(db);
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+    await server.stop();
+  });
+
+  describe('createLabel and updateLabel query', () => {
+    beforeAll(async () => {
+      // Create a label
+      label1 = await createLabelHelper(db, 'simon-le-bon');
+    });
+    it('should succeed if a user has FULLACCESS access', async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `${FULLACCESS}`,
+      };
+
+      // crete new label
+      const resultCreate = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(CREATE_LABEL),
+          variables: { name: 'katerina-ch-1' },
+        });
+
+      // we shouldn't have any errors
+      expect(resultCreate.body.errors).not.to.exist;
+
+      expect(resultCreate.body.data).to.exist;
+
+      // update label simon-le-bon to simon-le-bon-update
+      const input: UpdateLabelInput = {
+        externalId: label1.externalId,
+        name: 'simon-le-bon-update',
+      };
+      const resultUpdate = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_LABEL),
+          variables: { data: input },
+        });
+
+      // we shouldn't have any errors
+      expect(resultUpdate.body.errors).not.to.exist;
+
+      expect(resultUpdate.body.data).to.exist;
+    });
+    it('should fail if a user has only READONLY access', async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2,${READONLY}`,
+      };
+
+      // crete new label
+      const resultCreate = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(CREATE_LABEL),
+          variables: { name: 'katerina-ch-1' },
+        });
+
+      expect(resultCreate.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+
+      expect(resultCreate.body.data).not.to.exist;
+
+      // update label simon-le-bon to simon-le-bon-update
+      const input: UpdateLabelInput = {
+        externalId: label1.externalId,
+        name: 'simon-le-bon-update',
+      };
+      const resultUpdate = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_LABEL),
+          variables: { data: input },
+        });
+
+      expect(resultUpdate.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+
+      expect(resultUpdate.body.data).not.to.exist;
+    });
+
+    it('should fail if user does not have access', async () => {
+      const headers = {
+        name: 'Test User',
+        username: 'test.user@test.com',
+        groups: `group1,group2`,
+      };
+
+      // crete new label
+      const resultCreate = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(CREATE_LABEL),
+          variables: { name: 'katerina-ch-1' },
+        });
+
+      expect(resultCreate.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+
+      expect(resultCreate.body.data).not.to.exist;
+
+      // update label simon-le-bon to simon-le-bon-update
+      const input: UpdateLabelInput = {
+        externalId: label1.externalId,
+        name: 'simon-le-bon-update',
+      };
+      const resultUpdate = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_LABEL),
+          variables: { data: input },
+        });
+
+      expect(resultUpdate.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+
+      expect(resultUpdate.body.data).not.to.exist;
+    });
+
+    it('should fail if auth headers are empty', async () => {
+      // crete new label
+      const resultCreate = await request(app)
+        .post(graphQLUrl)
+        .send({
+          query: print(CREATE_LABEL),
+          variables: { name: 'katerina-ch-1' },
+        });
+
+      expect(resultCreate.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+
+      expect(resultCreate.body.data).not.to.exist;
+
+      // update label simon-le-bon to simon-le-bon-update
+      const input: UpdateLabelInput = {
+        externalId: label1.externalId,
+        name: 'simon-le-bon-update',
+      };
+      const resultUpdate = await request(app)
+        .post(graphQLUrl)
+        .send({
+          query: print(UPDATE_LABEL),
+          variables: { data: input },
+        });
+
+      expect(resultUpdate.body.errors[0].message).to.equal(ACCESS_DENIED_ERROR);
+
+      expect(resultUpdate.body.data).not.to.exist;
+    });
+  });
+});

--- a/src/admin/resolvers/mutations/Label.integration.ts
+++ b/src/admin/resolvers/mutations/Label.integration.ts
@@ -4,9 +4,17 @@ import request from 'supertest';
 import { ApolloServer } from '@apollo/server';
 import { PrismaClient } from '@prisma/client';
 import { client } from '../../../database/client';
-
-import { clear as clearDb, createLabelHelper } from '../../../test/helpers';
-import { CREATE_LABEL } from './sample-mutations.gql';
+import { CollectionLanguage, UpdateLabelInput } from '../../../database/types';
+import {
+  clear as clearDb,
+  createLabelHelper,
+  createAuthorHelper,
+} from '../../../test/helpers';
+import {
+  CREATE_COLLECTION,
+  CREATE_LABEL,
+  UPDATE_LABEL,
+} from './sample-mutations.gql';
 import { COLLECTION_CURATOR_FULL } from '../../../shared/constants';
 import { startServer } from '../../../express';
 import { IAdminContext } from '../../context';
@@ -63,6 +71,118 @@ describe('mutations: Label', () => {
       expect(result.body.errors.length).to.equal(1);
       expect(result.body.errors[0].message).to.equal(
         `A label with the name "simon-le-bon" already exists`
+      );
+    });
+
+    it('should successfully update the label', async () => {
+      // create label first
+      const resultCreate = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(CREATE_LABEL),
+          variables: { name: 'fake-label-1' },
+        });
+      expect(resultCreate.body.data.createLabel.name).to.equal('fake-label-1');
+
+      const input: UpdateLabelInput = {
+        externalId: resultCreate.body.data.createLabel.externalId,
+        name: 'fake-label-1-update',
+      };
+
+      const resultUpdate = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_LABEL),
+          variables: { data: input },
+        });
+      expect(resultUpdate.body.data.updateLabel.name).to.equal(
+        'fake-label-1-update'
+      );
+      expect(resultUpdate.body.data.updateLabel.externalId).to.equal(
+        resultCreate.body.data.createLabel.externalId
+      );
+    });
+
+    it('should throw an error when using an existing label name to update a label', async () => {
+      // create label first
+      const resultCreate = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(CREATE_LABEL),
+          variables: { name: 'fake-label-2' },
+        });
+      expect(resultCreate.body.data.createLabel.name).to.equal('fake-label-2');
+
+      const input: UpdateLabelInput = {
+        externalId: resultCreate.body.data.createLabel.externalId,
+        name: 'simon-le-bon',
+      };
+
+      const resultUpdate = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_LABEL),
+          variables: { data: input },
+        });
+      expect(resultUpdate.body.data).not.to.exist;
+      expect(resultUpdate.body.errors.length).to.equal(1);
+      expect(resultUpdate.body.errors[0].message).to.equal(
+        `A label with the name "simon-le-bon" already exists`
+      );
+    });
+
+    it('should throw an error when updating a label attached to a collection', async () => {
+      const author = await createAuthorHelper(db, 'walter');
+      const label1 = await createLabelHelper(db, 'most-read');
+      const minimumData = {
+        authorExternalId: author.externalId,
+        language: CollectionLanguage.EN,
+        slug: 'walter-bowls',
+        title: 'walter bowls',
+      };
+
+      // create collection first with label
+      const resultCollection = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(CREATE_COLLECTION),
+          variables: {
+            data: {
+              ...minimumData,
+              labelExternalIds: [label1.externalId],
+            },
+          },
+        });
+
+      expect(
+        resultCollection.body.data.createCollection.labels[0].externalId
+      ).to.equal(label1.externalId);
+      expect(
+        resultCollection.body.data.createCollection.labels[0].name
+      ).to.equal(label1.name);
+
+      // try to update the label
+      const input: UpdateLabelInput = {
+        externalId: label1.externalId,
+        name: 'fake-new-label-update',
+      };
+
+      const resultUpdate = await request(app)
+        .post(graphQLUrl)
+        .set(headers)
+        .send({
+          query: print(UPDATE_LABEL),
+          variables: { data: input },
+        });
+      expect(resultUpdate.body.data).not.to.exist;
+      expect(resultUpdate.body.errors.length).to.equal(1);
+      expect(resultUpdate.body.errors[0].message).to.equal(
+        `Cannot update label; it is associated with at least one collection`
       );
     });
   });

--- a/src/admin/resolvers/mutations/sample-mutations.gql.ts
+++ b/src/admin/resolvers/mutations/sample-mutations.gql.ts
@@ -191,3 +191,12 @@ export const CREATE_LABEL = gql`
     }
   }
 `;
+
+export const UPDATE_LABEL = gql`
+  mutation updateLabel($data: UpdateLabelInput!) {
+    updateLabel(data: $data) {
+      name
+      externalId
+    }
+  }
+`;

--- a/src/database/mutations.ts
+++ b/src/database/mutations.ts
@@ -10,7 +10,7 @@ export {
   updateCollection,
   updateCollectionImageUrl,
 } from './mutations/Collection';
-export { createLabel } from './mutations/Label';
+export { createLabel, updateLabel } from './mutations/Label';
 export {
   createCollectionPartner,
   updateCollectionPartner,

--- a/src/database/mutations/Label.ts
+++ b/src/database/mutations/Label.ts
@@ -13,6 +13,7 @@ export async function createLabel(
   name: string,
   authenticatedUser: AdminAPIUser
 ): Promise<Label> {
+  // check if label with updated name already exists
   const labelNameCount = await db.label.count({
     where: {
       name: name,
@@ -37,17 +38,6 @@ export async function updateLabel(
   data: UpdateLabelInput,
   authenticatedUser: AdminAPIUser
 ): Promise<Label> {
-  // first check if label with updated name already exists
-  const labelNameCount = await db.label.count({
-    where: {
-      name: data.name,
-    },
-  });
-  if (labelNameCount > 0) {
-    throw new UserInputError(
-      `A label with the name "${data.name}" already exists`
-    );
-  }
   // get count for collection-label association for label to update
   const collectionLabelAssociationCount = await db.collection.count({
     where: {
@@ -61,6 +51,17 @@ export async function updateLabel(
   if (collectionLabelAssociationCount > 0) {
     throw new UserInputError(
       `Cannot update label; it is associated with at least one collection`
+    );
+  }
+  // check if label with updated name already exists
+  const labelNameCount = await db.label.count({
+    where: {
+      name: data.name,
+    },
+  });
+  if (labelNameCount > 0) {
+    throw new UserInputError(
+      `A label with the name "${data.name}" already exists`
     );
   }
 

--- a/src/database/mutations/Label.ts
+++ b/src/database/mutations/Label.ts
@@ -29,7 +29,7 @@ export async function createLabel(
 
 /**
  * @param db
- * @param name
+ * @param data
  * @param authenticatedUser
  */
 export async function updateLabel(
@@ -60,7 +60,7 @@ export async function updateLabel(
   // if there is at least one collection-label association, don't allow update
   if (collectionLabelAssociationCount > 0) {
     throw new UserInputError(
-      `Cannot update label ${data.name}; it is associated with at least one collection`
+      `Cannot update label; it is associated with at least one collection`
     );
   }
 

--- a/src/database/mutations/Label.ts
+++ b/src/database/mutations/Label.ts
@@ -1,6 +1,7 @@
 import { Label, PrismaClient } from '@prisma/client';
 import { AdminAPIUser } from '../../admin/context';
 import { UserInputError } from '@pocket-tools/apollo-utils';
+import { UpdateLabelInput } from '../types';
 
 /**
  * @param db
@@ -23,5 +24,48 @@ export async function createLabel(
 
   return db.label.create({
     data: { name: name, createdBy: authenticatedUser.username },
+  });
+}
+
+/**
+ * @param db
+ * @param name
+ * @param authenticatedUser
+ */
+export async function updateLabel(
+  db: PrismaClient,
+  data: UpdateLabelInput,
+  authenticatedUser: AdminAPIUser
+): Promise<Label> {
+  // first check if label with updated name already exists
+  const labelNameCount = await db.label.count({
+    where: {
+      name: data.name,
+    },
+  });
+  if (labelNameCount > 0) {
+    throw new UserInputError(
+      `A label with the name "${data.name}" already exists`
+    );
+  }
+  // get count for collection-label association for label to update
+  const collectionLabelAssociationCount = await db.collection.count({
+    where: {
+      labels: {
+        some: { label: { externalId: data.externalId } },
+      },
+    },
+  });
+
+  // if there is at least one collection-label association, don't allow update
+  if (collectionLabelAssociationCount > 0) {
+    throw new UserInputError(
+      `Cannot update label ${data.name}; it is associated with at least one collection`
+    );
+  }
+
+  return db.label.update({
+    where: { externalId: data.externalId },
+    data: { name: data.name, updatedBy: authenticatedUser.username },
   });
 }

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -60,6 +60,11 @@ export type CreateCollectionInput = {
   title: string;
 };
 
+export type UpdateLabelInput = {
+  externalId: string;
+  name: string;
+};
+
 export type UpdateCollectionInput = {
   authorExternalId: string;
   curationCategoryExternalId?: string;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -4,5 +4,7 @@ export const COLLECTION_CURATOR_FULL =
 
 export const READONLY = 'team_pocket';
 
+export const FULLACCESS = 'mozilliansorg_pocket_collection_curator_full';
+
 export const ACCESS_DENIED_ERROR =
   'You do not have access to perform this action.';


### PR DESCRIPTION
## Goal

* Add the `updateLabel` mutation to allow curators to update label names, but prevent updating labels that are already attached to collections.
* Add relative tests.
* Also update one small thing in the PR template.

## Todos

- [x] Deploy to dev

## Tickets

- [https://getpocket.atlassian.net/browse/INFRA-936](https://getpocket.atlassian.net/browse/INFRA-936)