### PR TITLE
fix(uptime check): add uptime check to alert if popular collections site is not returning 2xx

### DIFF
--- a/.aws/.gitignore
+++ b/.aws/.gitignore
@@ -1,4 +1,5 @@
 .terraform/
 node_modules/
+!src/files/nodejs/node_modules
 cdktf.out/
 .gen/

--- a/.aws/src/files/nodejs/node_modules/synthetic.ts
+++ b/.aws/src/files/nodejs/node_modules/synthetic.ts
@@ -1,0 +1,70 @@
+// adapted from https://github.com/catalystsquad/terraform-aws-catalyst-platform/blob/main/assets/default-synthetics-lambda-function/index.js
+const synthetics = require('Synthetics');
+const log = require('SyntheticsLogger');
+const syntheticsConfiguration = synthetics.getConfiguration();
+const syntheticsLogHelper = require('SyntheticsLogHelper');
+
+const checkPage = async function () {
+  // check if the URL environment variable is set
+  if (!('URL' in process.env)) {
+    throw new Error('Missing URL environment variable!');
+  }
+
+  let url = process.env.URL;
+
+  syntheticsConfiguration.disableStepScreenshots();
+  syntheticsConfiguration.setConfig({
+    continueOnStepFailure: true,
+    includeRequestHeaders: true,
+    includeResponseHeaders: true,
+    restrictedHeaders: [],
+    restrictedUrlParameters: [],
+  });
+
+  let page = await synthetics.getPage();
+
+  await loadUrl(page, url);
+};
+
+const loadUrl = async function (page, url) {
+  let stepName = null;
+  let domcontentloaded = false;
+
+  try {
+    stepName = new URL(url).hostname;
+  } catch (error) {
+    const errorString = `Error parsing url: ${url}.  ${error}`;
+    log.error(errorString);
+    // throw error is can't parse URL
+    throw error;
+  }
+
+  await synthetics.executeStep(stepName, async function () {
+    const sanitizedUrl = syntheticsLogHelper.getSanitizedUrl(url);
+    const response = await page.goto(url, {
+      waitUntil: ['domcontentloaded'],
+      timeout: 30000,
+    });
+    if (response) {
+      domcontentloaded = true;
+      const status = response.status();
+      const statusText = response.statusText();
+
+      // If the response status code is not a 2xx success code
+      if (status < 200 || status > 299) {
+        throw `Failed to load url: ${sanitizedUrl} ${status} ${statusText}`;
+      }
+
+      const logResponseString = `Response from url: ${sanitizedUrl}  Status: ${status}  Status Text: ${statusText}`;
+      console.log(logResponseString);
+    } else {
+      const logNoResponseString = `No response returned for url: ${sanitizedUrl}`;
+      log.error(logNoResponseString);
+      throw new Error(logNoResponseString);
+    }
+  });
+};
+
+exports.handler = async () => {
+  return await checkPage();
+};

--- a/.aws/src/monitoring.ts
+++ b/.aws/src/monitoring.ts
@@ -1,0 +1,190 @@
+import { config } from './config';
+import { Construct } from 'constructs';
+import { AssetType, TerraformAsset } from 'cdktf';
+import * as path from 'path';
+import { DataArchiveFile } from '@cdktf/provider-archive';
+import {
+  cloudwatch,
+  DataAwsDefaultTags,
+  datasources,
+  iam,
+  synthetics,
+  s3,
+} from '@cdktf/provider-aws';
+
+/**
+ * Create additional monitoring
+ * @param app
+ * @param provider
+ */
+export class CollectionAPIMonitoring extends Construct {
+  public readonly scope: Construct;
+  public readonly name: string;
+
+  constructor(scope: Construct, name: string) {
+    super(scope, name);
+
+    new DataAwsDefaultTags(this, 'monitoring_default_tags', {
+      tags: config.tags,
+    });
+  }
+
+  createSyntheticCheck(checkUrl: string, snsCriticalAlarmTopicARN: string) {
+    const caller = new datasources.DataAwsCallerIdentity(this, 'caller');
+    const region = new datasources.DataAwsRegion(this, 'region');
+
+    const syncheckArtifactsS3 = new s3.S3Bucket(
+      this,
+      'synthetic_check_artifacts',
+      {
+        bucket: `pocket-${config.prefix.toLowerCase()}-synthetic-check`,
+      }
+    );
+
+    const syntheticCode = new TerraformAsset(this, 'synthetic_check_asset', {
+      path: path.resolve(`${__dirname}`, 'files'),
+      type: AssetType.DIRECTORY,
+    });
+
+    const syncheckZipFile = new DataArchiveFile(this, 'synthetic_check_zip', {
+      outputPath: `generated-archives/synthetic-${syntheticCode.assetHash}.zip`,
+      sourceDir: syntheticCode.path,
+      type: 'zip',
+    });
+
+    // behind the scenes, Cloudwatch Synthetics are AWS-managed Lambdas
+    const dataSyncheckAssume = new iam.DataAwsIamPolicyDocument(
+      this,
+      'synthetic_check_assume',
+      {
+        version: '2012-10-17',
+        statement: [
+          {
+            effect: 'Allow',
+            actions: ['sts:AssumeRole'],
+
+            principals: [
+              {
+                identifiers: ['lambda.amazonaws.com'],
+                type: 'Service',
+              },
+            ],
+          },
+        ],
+      }
+    );
+
+    const syncheckRole = new iam.IamRole(this, 'synthetic_check_role', {
+      name: `pocket-${config.prefix.toLowerCase()}-synthetic-check`,
+
+      assumeRolePolicy: dataSyncheckAssume.json,
+      tags: config.tags,
+    });
+
+    // puts artifacts into s3, stores logs, pushes metrics to Cloudwatch
+    const dataSynCheckAccess = new iam.DataAwsIamPolicyDocument(
+      this,
+      'synthetic_check_access',
+      {
+        version: '2012-10-17',
+        statement: [
+          {
+            effect: 'Allow',
+            actions: [
+              'logs:CreateLogGroup',
+              'logs:CreateLogStream',
+              'logs:PutLogEvents',
+            ],
+            resources: [
+              `arn:aws:logs:${region.id}:${
+                caller.accountId
+              }:log-group:/aws/lambda/cwsyn-${config.prefix.toLowerCase()}-*`,
+            ],
+          },
+          {
+            actions: ['s3:PutObject', 's3:GetObject'],
+            resources: [`${syncheckArtifactsS3.arn}/*`],
+          },
+          {
+            actions: ['s3:GetBucketLocation'],
+            resources: [syncheckArtifactsS3.arn],
+          },
+          {
+            actions: ['s3:ListAllMyBuckets'],
+            resources: ['*'],
+          },
+          {
+            actions: ['cloudwatch:PutMetricData'],
+            resources: ['*'],
+            condition: [
+              {
+                test: 'StringEquals',
+                values: ['CloudWatchSynthetics'],
+                variable: 'cloudwatch:namespace',
+              },
+            ],
+          },
+        ],
+      }
+    );
+
+    const synCheckAccessPolicy = new iam.IamPolicy(
+      this,
+      'synthetic_check_access_policy',
+      {
+        name: `pocket-${config.prefix.toLowerCase()}-synthetic-check-access`,
+        policy: dataSynCheckAccess.json,
+      }
+    );
+
+    new iam.IamRolePolicyAttachment(this, 'synthetic_check_access_attach', {
+      role: syncheckRole.id,
+      policyArn: synCheckAccessPolicy.arn,
+    });
+
+    const synCheckCanary = new synthetics.SyntheticsCanary(
+      this,
+      'synthetic_check',
+      {
+        name: `${config.prefix.toLowerCase()}`, // limit of 21 characters
+
+        artifactS3Location: `s3://${syncheckArtifactsS3.bucket}/`,
+        executionRoleArn: syncheckRole.arn,
+        handler: 'synthetic.handler',
+        runConfig: {
+          environmentVariables: {
+            URL: checkUrl,
+          },
+          timeoutInSeconds: 180, // 3 minute timeout
+        },
+        runtimeVersion: 'syn-nodejs-puppeteer-3.9',
+        schedule: {
+          expression: 'rate(5 minutes)', // run every 5 minutes
+        },
+        startCanary: true,
+        zipFile: syncheckZipFile.outputPath,
+      }
+    );
+
+    new cloudwatch.CloudwatchMetricAlarm(this, 'synthetic_check_alarm', {
+      alarmDescription: `Alert when ${synCheckCanary.name} canary success percentage has decreased below 66% in the last 15 minutes`,
+      alarmName: `pocket-${config.prefix.toLowerCase()}-synthetic-check-access`,
+
+      comparisonOperator: 'LessThanThreshold',
+      dimensions: {
+        CanaryName: synCheckCanary.name,
+      },
+      evaluationPeriods: 3,
+      metricName: 'SuccessPercent',
+      namespace: 'CloudWatchSynthetics',
+      period: 300, // 15 minutes
+      statistic: 'Average',
+      threshold: 66,
+      treatMissingData: 'breaching',
+
+      alarmActions: [snsCriticalAlarmTopicARN],
+      insufficientDataActions: [],
+      okActions: [snsCriticalAlarmTopicARN],
+    });
+  }
+}

--- a/.aws/tsconfig.json
+++ b/.aws/tsconfig.json
@@ -13,6 +13,6 @@
     "inlineSources": true,
     "sourceRoot": "/"
   },
-  "include": ["**/*.ts"],
+  "include": ["**/*.ts", "src/files/nodejs/node_modules/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Provides collections: A set of static curated stories around a central theme.
 
+## Application Healthcheck
+For the deployed application, there is a [Cloudwatch healthcheck](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#synthetics:canary/detail/collectionapi-prod), hooked up to [this alarm (which will page Backend Team via Pagerduty)](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarmsV2:alarm/pocket-collectionapi-prod-synthetic-check-access?~(search~'collection)).
+
 ## Application Overview
 
 [Express](https://expressjs.com/) is the Node framework, [Apollo Server](https://www.apollographql.com/docs/apollo-server/) is used in Express to expose a GraphQL API, and [Prisma](https://www.prisma.io/) is used as the ORM. [MySQL](https://www.mysql.com/) is the relational database, though in AWS this is [Aurora Serverless](https://aws.amazon.com/rds/aurora/serverless/). [S3](https://aws.amazon.com/s3/) is used for image storage, and S3 paths are mapped to entities in MySQL.


### PR DESCRIPTION
## Goal

Recent collection-api incident highlighted that existing monitoring was not alerting when collection sites were all 'down' (in this case, all returning 404).

This PR adds an AWS Cloudwatch-based Synthetic Canary which check https://getpocket.com/collections/pocket-best-of-2022-collections every 5 minutes, and if it gets lower than 66% success rate in a 15 minute period (success being the site returns a 2xx), it will alert Pagerduty.

This is setup to only be implemented for production.

## Todos

- [ ] There is a linked PR forthcoming that fixes the metrics-based alerting in terraform-modules to be more useful and that will come through here via later package upgrades.

- Link to docs

## Tickets

[- Link to JIRA tickets](https://getpocket.atlassian.net/browse/INFRA-1082)

## Implementation Decisions

Using Cloudwatch Synthetic Checks instead of New Relic since the Backend Team doesn't currently have access to New Relic, and it would suck to be paged for an alert you can't access.
