### PR TITLE
chore(docs): Add link to instructions for resetting the Dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ The current expectation is that our AWS dev environment may be reset/changed at 
 
 ### Resetting Dev
 
-There may come a time when you need to reset the dev environment. For example, if you were testing a schema change and then want to test a different branch _without_ that schema change, the dev database and Prisma schema will be out of sync.
+There may come a time when you need to reset the Dev environment. For example, if you were testing a schema change and then want to test a different branch _without_ that schema change, the dev database and Prisma schema will be out of sync.
+Another common scenario is the need to reset all test data to the initial seed data provided by the seed script.
 
-To reset the dev database, ask for instructions in Slack.
+To reset the Dev database, [follow the instructions in Confluence](https://getpocket.atlassian.net/wiki/spaces/PE/pages/2938273799/Resetting+Data+for+a+Prisma-based+Subgraph+on+Dev).


### PR DESCRIPTION
## Goal

Update the docs so that instructions for something that is rarely needed in practice don't get lost.

## Tickets

- unticketed. Related to the recent need to reseed the data on Dev for Shareable Lists API.
