### PR TITLE
Enable variable and error messages in studio

### DIFF
--- a/src/public/server.ts
+++ b/src/public/server.ts
@@ -44,8 +44,8 @@ export function getPublicServer(
       },
       sendErrors: {
         unmodified: true,
-      }
-    })
+      },
+    }),
   ];
   const nonProdPlugins = [
     ApolloServerPluginLandingPageGraphQLPlayground(),

--- a/src/public/server.ts
+++ b/src/public/server.ts
@@ -37,6 +37,14 @@ export function getPublicServer(
   const prodPlugins = [
     ApolloServerPluginLandingPageDisabled(),
     ApolloServerPluginInlineTrace(),
+    ApolloServerPluginUsageReporting({
+      sendVariableValues: {
+        all: true,
+      },
+      sendErrors: {
+        unmodified: true,
+      }
+    })
   ];
   const nonProdPlugins = [
     ApolloServerPluginLandingPageGraphQLPlayground(),

--- a/src/public/server.ts
+++ b/src/public/server.ts
@@ -14,6 +14,7 @@ import {
 import { ApolloServerPluginInlineTrace } from '@apollo/server/plugin/inlineTrace';
 import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHttpServer';
 import { IPublicContext } from './context';
+import { ApolloServerPluginUsageReporting } from '@apollo/server/plugin/usageReporting';
 
 // export const server = new ApolloServer({
 export function getPublicServer(


### PR DESCRIPTION
## Goal

Enable variable and error messages in studio

## Todos

- [x] Verify parameters are safe
- [x] Enable parameter and error logging

## Reference

The issue:
<img width="1826" alt="Screenshot 2023-07-11 at 12 15 52 PM" src="https://github.com/Pocket/collection-api/assets/13011/e5029682-7b5a-404e-a327-fb4cce9d0151">

Verifying that query params all look safe
<img width="1083" alt="Screenshot 2023-07-11 at 12 49 15 PM" src="https://github.com/Pocket/collection-api/assets/13011/74a360d9-066c-42be-9952-edda22962e78">

