### PR TITLE
fix(pocketTools): Remove duplicate pocket tools package declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@apollo/server-plugin-response-cache": "4.1.3",
     "@apollo/subgraph": "2.5.1",
     "@aws-sdk/client-eventbridge": "^3.276.0",
-    "@pocket-tools/apollo-utils": "^3.4.0",
     "@pocket-tools/ts-logger": "^1.2.4",
     "@pocket-tools/apollo-utils": "3.4.2",
     "@prisma/client": "^4.16.2",


### PR DESCRIPTION
## Goal

Removing duplicate `@pocket-tools/...` package declaration


