### PR TITLE
chore(circleci): [INFRA-1364] Update CircleCI images from deprecated to current `cimg/node` ones

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ only_dev: &only_dev
 jobs:
   apollo:
     docker:
-      - image: circleci/node:16.13.1@sha256:1803e9ed7deec9456ad2609124b7333d40b2eec0cf34998ae766cbf90c9a3625
+      - image: cimg/node:18.16
     steps:
       - checkout
       - run:
@@ -163,7 +163,7 @@ jobs:
         description: 'Test scripts to run'
         type: string
     docker:
-      - image: circleci/node:16.13.1@sha256:1803e9ed7deec9456ad2609124b7333d40b2eec0cf34998ae766cbf90c9a3625
+      - image: cimg/node:18.16
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD


### PR DESCRIPTION
## Goal

Stop using deprecated CircleCI images - the newer ones were introduced in 2020: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

## Reference

https://getpocket.atlassian.net/browse/INFRA-1364
