### PR TITLE
chore(pagerduty):  [SOCIALPLAT-700] Remove this service from Tier 1 PagerDuty

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -185,8 +185,9 @@ class CollectionAPI extends TerraformStack {
     return new PocketPagerDuty(this, 'pagerduty', {
       prefix: config.prefix,
       service: {
+        // This is a Tier 2 service and as such only raises non-critical alarms.
         criticalEscalationPolicyId: incidentManagement
-          .get('policy_default_critical_id')
+          .get('policy_default_non_critical_id')
           .toString(),
         nonCriticalEscalationPolicyId: incidentManagement
           .get('policy_default_non_critical_id')
@@ -339,7 +340,7 @@ class CollectionAPI extends TerraformStack {
           threshold: 25, // 25%
           period: 300, // 5 minutes
           evaluationPeriods: 4, // 20 minutes total
-          actions: config.isDev ? [] : [pagerDuty.snsCriticalAlarmTopic.arn],
+          actions: config.isDev ? [] : [pagerDuty.snsNonCriticalAlarmTopic.arn],
         },
       },
     });


### PR DESCRIPTION
## Goal
 
Remove this service from Tier 1 PagerDuty policy.

One alarm was downgraded from critical to a non-critical one.

## References

JIRA ticket:
* https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-700