### PR TITLE
feat: more and bigger tasks, with faster scale-out

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -223,8 +223,8 @@ class CollectionAPI extends TerraformStack {
       cdn: false,
       domain: config.domain,
       taskSize: {
-          cpu: 1024,
-          memory: 8192,
+        cpu: 1024,
+        memory: 8192,
       },
       containerConfigs: [
         {
@@ -338,7 +338,7 @@ class CollectionAPI extends TerraformStack {
         // Even though task count scaled out to 10, the CPU load was still 80%.
         // Allow for faster auto-scaling to handle request spikes from scheduled tasks.
         targetMinCapacity: config.environment === 'Prod' ? 4 : 1,
-        targetMaxCapacity: config.environment === 'Prod' ? 20: 4,
+        targetMaxCapacity: config.environment === 'Prod' ? 20 : 4,
         scaleOutThreshold: 25,
         scaleInThreshold: 15,
         stepScaleOutAdjustment: 4,


### PR DESCRIPTION
## Goal
Prospects were not generated in the last 2 days, because collection hydration failed.

Handle spikes in requests better, to prevent spikes in latency and 5xx error rate.

![Screenshot from 2023-10-30 09-20-17](https://github.com/Pocket/collection-api/assets/1547251/9c642b20-aef3-458a-b7dd-26c4bd082685)

## Reference

- [Incident doc](https://docs.google.com/document/d/1mMtP0337OqJBXEu-RkvzoH-O8YabErH9BycR1fZdvyc/edit)
- [Incident Slack thread](https://mozilla.slack.com/archives/C05EAHBM35Z/p1698683597264689)

## Implementation Decisions
- Increase memory from 2GB to 8GB, because _average_ memory was often above 50% during the incident, with spikes up to 90%.
- Increase from .5 vCPU to 1 vCPU
- Increase stepScaleOutAdjustment from 2 to 4, to be able to scale out faster when there is sustained higher load.
- Increase maximum number of tasks to 20. Probably not necessary with the above changes, but the service was not able to handle the load at 10 tasks.