### PR TITLE
perf(ts-logger): remove ts-logger to attempt to mitigate memory issues

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,6 @@
   "useTabs": false,
   "tabWidth": 2,
   "semi": true,
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "all"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5101,7 +5101,8 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -9673,6 +9674,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dev": true,
       "dependencies": {
         "abbrev": "1"
       },

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,9 +17,7 @@ import {
   createIABCategoryHelper,
   createPartnerHelper,
 } from '../src/test/helpers';
-import { setLogger } from '@pocket-tools/ts-logger';
 
-const prismaSeedLogger = setLogger();
 const prisma = new PrismaClient();
 
 async function main() {
@@ -36,13 +34,13 @@ async function main() {
   const katerinaLabel = await createLabelHelper(
     prisma,
     'region-west-africa',
-    'kchinnappan',
+    'kchinnappan'
   );
 
   const herrajLabel = await createLabelHelper(
     prisma,
     'region-east-europe',
-    'hluhano',
+    'hluhano'
   );
 
   // create Label with default values
@@ -53,7 +51,7 @@ async function main() {
 
   const curationCategory1 = await createCurationCategoryHelper(
     prisma,
-    'Lorem Ipsum',
+    'Lorem Ipsum'
   );
 
   // create Collection - Label association
@@ -98,18 +96,18 @@ async function main() {
 
   const curationCategory2 = await createCurationCategoryHelper(
     prisma,
-    'Bowling',
+    'Bowling'
   );
 
   const IABParentCategory = await createIABCategoryHelper(
     prisma,
-    'Entertainment',
+    'Entertainment'
   );
 
   const IABChildCategory = await createIABCategoryHelper(
     prisma,
     'Live Music',
-    IABParentCategory,
+    IABParentCategory
   );
 
   const collection1 = await createCollectionHelper(prisma, {
@@ -218,7 +216,7 @@ async function main() {
 
 main()
   .catch((e) => {
-    prismaSeedLogger.error({ error: e, message: 'primsa seed main() error' });
+    console.error(e);
     process.exit(1);
   })
   .finally(async () => {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -34,13 +34,13 @@ async function main() {
   const katerinaLabel = await createLabelHelper(
     prisma,
     'region-west-africa',
-    'kchinnappan'
+    'kchinnappan',
   );
 
   const herrajLabel = await createLabelHelper(
     prisma,
     'region-east-europe',
-    'hluhano'
+    'hluhano',
   );
 
   // create Label with default values
@@ -51,7 +51,7 @@ async function main() {
 
   const curationCategory1 = await createCurationCategoryHelper(
     prisma,
-    'Lorem Ipsum'
+    'Lorem Ipsum',
   );
 
   // create Collection - Label association
@@ -96,18 +96,18 @@ async function main() {
 
   const curationCategory2 = await createCurationCategoryHelper(
     prisma,
-    'Bowling'
+    'Bowling',
   );
 
   const IABParentCategory = await createIABCategoryHelper(
     prisma,
-    'Entertainment'
+    'Entertainment',
   );
 
   const IABChildCategory = await createIABCategoryHelper(
     prisma,
     'Live Music',
-    IABParentCategory
+    IABParentCategory,
   );
 
   const collection1 = await createCollectionHelper(prisma, {

--- a/src/database/client.ts
+++ b/src/database/client.ts
@@ -1,5 +1,4 @@
 import { PrismaClient } from '@prisma/client';
-import { serverLogger } from '../express';
 import { collectionStoryInjectItemMiddleware } from '../middleware/prisma';
 
 let prisma;
@@ -7,45 +6,11 @@ let prisma;
 export function client(): PrismaClient {
   if (prisma) return prisma;
 
+  // Always log errors
+  const logOptions: any[] = ['error'];
+
   prisma = new PrismaClient({
-    log: [
-      {
-        level: 'error',
-        emit: 'event',
-      },
-      {
-        level: 'warn',
-        emit: 'event',
-      },
-      {
-        level: 'info',
-        emit: 'event',
-      },
-      {
-        level: 'query',
-        emit: 'event',
-      },
-    ],
-  });
-
-  prisma.$on('error', (e) => {
-    e.source = 'prisma';
-    serverLogger.error(e);
-  });
-
-  prisma.$on('warn', (e) => {
-    e.source = 'prisma';
-    serverLogger.warn(e);
-  });
-
-  prisma.$on('info', (e) => {
-    e.source = 'prisma';
-    serverLogger.info(e);
-  });
-
-  prisma.$on('query', (e) => {
-    e.source = 'prisma';
-    serverLogger.debug(e);
+    log: logOptions,
   });
 
   // this is a middleware function that injects non-database / non-prisma

--- a/src/events/events.spec.ts
+++ b/src/events/events.spec.ts
@@ -60,7 +60,7 @@ describe('event helpers: ', () => {
       const payload = await events.generateEventBridgePayload(
         dbClient,
         EventBridgeEventType.COLLECTION_CREATED,
-        { ...testCollection, status: 'ARCHIVED', publishedAt: undefined }
+        { ...testCollection, status: 'ARCHIVED', publishedAt: undefined },
       );
 
       // assert that db call to fetch labels for collection via CollectionLabel ids is called
@@ -76,7 +76,7 @@ describe('event helpers: ', () => {
 
       expect(payload.collection.status).to.equal('archived');
       expect(payload.collection.language).to.equal(
-        CollectionLanguage[testCollection.language]
+        CollectionLanguage[testCollection.language],
       );
       expect(payload.collection.authors.length).to.equal(0);
       expect(payload.collection.stories.length).to.equal(0);
@@ -96,7 +96,7 @@ describe('event helpers: ', () => {
 
       // assert the remaining two props of the payload object are correct
       expect(payload.eventType).to.equal(
-        EventBridgeEventType.COLLECTION_CREATED
+        EventBridgeEventType.COLLECTION_CREATED,
       );
       expect(payload.object_version).to.equal('new');
     });
@@ -115,11 +115,11 @@ describe('event helpers: ', () => {
       const payload = await events.generateEventBridgePayload(
         dbClient,
         EventBridgeEventType.COLLECTION_UPDATED,
-        dbCollection
+        dbCollection,
       );
 
       expect(payload.collection.status).to.equal(
-        CollectionStatus[testCollection.status]
+        CollectionStatus[testCollection.status],
       );
       expect(payload.collection.publishedAt).to.equal(1672549200);
 
@@ -202,7 +202,7 @@ describe('event helpers: ', () => {
       const payload = await events.generateEventBridgePayload(
         dbClient,
         EventBridgeEventType.COLLECTION_CREATED,
-        testCollection
+        testCollection,
       );
 
       await events.sendEvent(payload);
@@ -229,7 +229,7 @@ describe('event helpers: ', () => {
 
       // Compare to initial payload
       expect(sendCommand.Entries[0]['Detail']).to.equal(
-        JSON.stringify(payload)
+        JSON.stringify(payload),
       );
     });
 
@@ -246,7 +246,7 @@ describe('event helpers: ', () => {
       let payload = await events.generateEventBridgePayload(
         dbClient,
         EventBridgeEventType.COLLECTION_CREATED,
-        testCollection
+        testCollection,
       );
 
       await events.sendEvent(payload);
@@ -258,11 +258,11 @@ describe('event helpers: ', () => {
 
       expect(sentryStub.callCount).to.equal(1);
       expect(sentryStub.getCall(0).firstArg.message).to.contain(
-        `sendEvent: Failed to send event 'collection-created' to event bus`
+        `sendEvent: Failed to send event 'collection-created' to event bus`,
       );
       expect(consoleSpy.callCount).to.equal(1);
       expect(consoleSpy.getCall(0).firstArg.message).to.contain(
-        `Failed to send event 'collection-created' to event bus`
+        `Failed to send event 'collection-created' to event bus`,
       );
 
       /**
@@ -276,7 +276,7 @@ describe('event helpers: ', () => {
       payload = await events.generateEventBridgePayload(
         dbClient,
         EventBridgeEventType.COLLECTION_UPDATED, // event type i collection-updated
-        testCollection
+        testCollection,
       );
 
       await events.sendEvent(payload);
@@ -288,11 +288,11 @@ describe('event helpers: ', () => {
 
       expect(sentryStub.callCount).to.equal(1);
       expect(sentryStub.getCall(0).firstArg.message).to.contain(
-        `Failed to send event 'collection-updated' to event bus`
+        `Failed to send event 'collection-updated' to event bus`,
       );
       expect(consoleSpy.callCount).to.equal(1);
       expect(consoleSpy.getCall(0).firstArg.message).to.contain(
-        `sendEvent: Failed to send event 'collection-updated' to event bus`
+        `sendEvent: Failed to send event 'collection-updated' to event bus`,
       );
     });
   });
@@ -307,7 +307,7 @@ describe('event helpers: ', () => {
       await events.sendEventBridgeEvent(
         dbClient,
         EventBridgeEventType.COLLECTION_CREATED,
-        testCollection
+        testCollection,
       );
 
       // Wait in case promise needs time to resolve
@@ -319,11 +319,11 @@ describe('event helpers: ', () => {
       expect(sentryStub.getCall(0).firstArg.message).to.contain('boo!');
       expect(crumbStub.callCount).to.equal(1);
       expect(crumbStub.getCall(0).firstArg.message).to.contain(
-        `sendEventBridgeEvent: Failed to send event 'collection-created' to event bus`
+        `sendEventBridgeEvent: Failed to send event 'collection-created' to event bus`,
       );
       expect(consoleSpy.callCount).to.equal(2);
       expect(consoleSpy.getCall(0).firstArg.message).to.contain(
-        `sendEventBridgeEvent: Failed to send event 'collection-created' to event bus`
+        `sendEventBridgeEvent: Failed to send event 'collection-created' to event bus`,
       );
       expect(consoleSpy.getCall(1).firstArg.message).to.equal('boo!');
     });

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -36,14 +36,13 @@ import {
   IABCategory as dbIABCategory,
   CollectionLabel,
 } from '@prisma/client';
-import { serverLogger } from '../express';
 
 import { getLabelById } from '../shared/resolvers/types';
 
 /** Transformation functions below to map collection object's sub types to the ones in snowplow schema  */
 
 function transformCollectionAuthors(
-  collectionAuthors: dbCollectionAuthor[],
+  collectionAuthors: dbCollectionAuthor[]
 ): CollectionAuthor[] {
   return collectionAuthors.map((author) => {
     const { externalId, name, active, slug, bio, imageUrl } = author;
@@ -59,7 +58,7 @@ function transformCollectionAuthors(
 }
 
 function transformStoryAuthor(
-  collectionStoryAuthors: dbCollectionStoryAuthor[],
+  collectionStoryAuthors: dbCollectionStoryAuthor[]
 ): CollectionStoryAuthor[] {
   return collectionStoryAuthors.map((storyAuthor) => {
     return {
@@ -70,7 +69,7 @@ function transformStoryAuthor(
 }
 
 function transformCollectionStories(
-  collectionStories: dbCollectionStoryWithAuthors[],
+  collectionStories: dbCollectionStoryWithAuthors[]
 ): CollectionStory[] {
   return collectionStories.map((collectionStory) => {
     const {
@@ -109,7 +108,7 @@ function transformCollectionLabels(collectionLabels: dbLabel[]): Label[] {
 }
 
 function transformCollectionCurationCategory(
-  curationCategory: dbCurationCategory,
+  curationCategory: dbCurationCategory
 ): CurationCategory {
   const { externalId, name, slug } = curationCategory;
   return {
@@ -120,7 +119,7 @@ function transformCollectionCurationCategory(
 }
 
 function transformCollectionPartnership(
-  collectionPartnership: dbCollectionPartnership,
+  collectionPartnership: dbCollectionPartnership
 ): CollectionPartnership {
   const { externalId, imageUrl, type, blurb, name, url } =
     collectionPartnership;
@@ -135,7 +134,7 @@ function transformCollectionPartnership(
 }
 
 function transformCollectionIABParentCategory(
-  iabCategory: dbIABCategory,
+  iabCategory: dbIABCategory
 ): IABParentCategory {
   const { externalId, name, slug } = iabCategory;
   return {
@@ -146,7 +145,7 @@ function transformCollectionIABParentCategory(
 }
 
 function transformCollectionIABChildCategory(
-  iabCategory: dbIABCategory,
+  iabCategory: dbIABCategory
 ): IABChildCategory {
   const { externalId, name, slug } = iabCategory;
   return {
@@ -161,7 +160,7 @@ function transformCollectionIABChildCategory(
  */
 export const getCollectionLabelsForSnowplow = async (
   dbClient: PrismaClient,
-  collectionLabels: CollectionLabel[],
+  collectionLabels: CollectionLabel[]
 ): Promise<dbLabel[]> => {
   const labels: dbLabel[] = [];
   // collectionLabel variable here represents the collection-label connection entity
@@ -184,7 +183,7 @@ function getDateInSeconds(date: Date): number {
  */
 export function transformDbCollectionToSnowplowCollection(
   collection: CollectionComplete,
-  collectionLabels: dbLabel[],
+  collectionLabels: dbLabel[]
 ): Collection {
   const hasAuthors = collection.authors && collection.authors.length !== 0;
   const hasStories = collection.stories && collection.stories.length !== 0;
@@ -228,7 +227,7 @@ export function transformDbCollectionToSnowplowCollection(
 export async function generateEventBridgePayload(
   dbClient: PrismaClient,
   eventType: EventBridgeEventType,
-  collection: CollectionComplete,
+  collection: CollectionComplete
 ): Promise<CollectionEventBusPayload> {
   // check if collection has any labels and fetch them
   const hasLabels = collection.labels && collection.labels.length !== 0;
@@ -239,7 +238,7 @@ export async function generateEventBridgePayload(
   return {
     collection: transformDbCollectionToSnowplowCollection(
       collection,
-      collectionLabels, // pass in collection labels to the main transform function
+      collectionLabels // pass in collection labels to the main transform function
     ),
     eventType: eventType,
     object_version: 'new',
@@ -253,12 +252,12 @@ export async function generateEventBridgePayload(
 export async function sendEventBridgeEvent(
   dbClient: PrismaClient,
   eventType: EventBridgeEventType,
-  collection: CollectionComplete,
+  collection: CollectionComplete
 ) {
   const payload = await generateEventBridgePayload(
     dbClient,
     eventType,
-    collection,
+    collection
   );
 
   // Send to Event Bridge. Yay!
@@ -270,19 +269,13 @@ export async function sendEventBridgeEvent(
     const failedEventError = new Error(
       `sendEventBridgeEvent: Failed to send event '${
         payload.eventType
-      }' to event bus. Event Body:\n ${JSON.stringify(payload)}`,
+      }' to event bus. Event Body:\n ${JSON.stringify(payload)}`
     );
     // Don't halt program, but capture the failure in Sentry and Cloudwatch
     Sentry.addBreadcrumb(failedEventError);
     Sentry.captureException(error);
-    serverLogger.error(
-      'sendEventBridgeEvent: Failed to send event to event bus',
-      {
-        eventType: payload.eventType,
-        payload: JSON.stringify(payload),
-        error,
-      },
-    );
+    console.log(failedEventError);
+    console.log(error);
   }
 }
 
@@ -305,21 +298,18 @@ export async function sendEvent(eventPayload: any) {
   });
 
   const output: PutEventsCommandOutput = await eventBridgeClient.send(
-    putEventCommand,
+    putEventCommand
   );
 
   if (output.FailedEntryCount) {
     const failedEventError = new Error(
       `sendEvent: Failed to send event '${
         eventPayload.eventType
-      }' to event bus. Event Body:\n ${JSON.stringify(eventPayload)}`,
+      }' to event bus. Event Body:\n ${JSON.stringify(eventPayload)}`
     );
 
     // Don't halt program, but capture the failure in Sentry and Cloudwatch
     Sentry.captureException(failedEventError);
-    serverLogger.error('sendEvent: Failed to send event to event bus', {
-      eventType: eventPayload.eventType,
-      payload: JSON.stringify(eventPayload),
-    });
+    console.log(failedEventError);
   }
 }

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -42,7 +42,7 @@ import { getLabelById } from '../shared/resolvers/types';
 /** Transformation functions below to map collection object's sub types to the ones in snowplow schema  */
 
 function transformCollectionAuthors(
-  collectionAuthors: dbCollectionAuthor[]
+  collectionAuthors: dbCollectionAuthor[],
 ): CollectionAuthor[] {
   return collectionAuthors.map((author) => {
     const { externalId, name, active, slug, bio, imageUrl } = author;
@@ -58,7 +58,7 @@ function transformCollectionAuthors(
 }
 
 function transformStoryAuthor(
-  collectionStoryAuthors: dbCollectionStoryAuthor[]
+  collectionStoryAuthors: dbCollectionStoryAuthor[],
 ): CollectionStoryAuthor[] {
   return collectionStoryAuthors.map((storyAuthor) => {
     return {
@@ -69,7 +69,7 @@ function transformStoryAuthor(
 }
 
 function transformCollectionStories(
-  collectionStories: dbCollectionStoryWithAuthors[]
+  collectionStories: dbCollectionStoryWithAuthors[],
 ): CollectionStory[] {
   return collectionStories.map((collectionStory) => {
     const {
@@ -108,7 +108,7 @@ function transformCollectionLabels(collectionLabels: dbLabel[]): Label[] {
 }
 
 function transformCollectionCurationCategory(
-  curationCategory: dbCurationCategory
+  curationCategory: dbCurationCategory,
 ): CurationCategory {
   const { externalId, name, slug } = curationCategory;
   return {
@@ -119,7 +119,7 @@ function transformCollectionCurationCategory(
 }
 
 function transformCollectionPartnership(
-  collectionPartnership: dbCollectionPartnership
+  collectionPartnership: dbCollectionPartnership,
 ): CollectionPartnership {
   const { externalId, imageUrl, type, blurb, name, url } =
     collectionPartnership;
@@ -134,7 +134,7 @@ function transformCollectionPartnership(
 }
 
 function transformCollectionIABParentCategory(
-  iabCategory: dbIABCategory
+  iabCategory: dbIABCategory,
 ): IABParentCategory {
   const { externalId, name, slug } = iabCategory;
   return {
@@ -145,7 +145,7 @@ function transformCollectionIABParentCategory(
 }
 
 function transformCollectionIABChildCategory(
-  iabCategory: dbIABCategory
+  iabCategory: dbIABCategory,
 ): IABChildCategory {
   const { externalId, name, slug } = iabCategory;
   return {
@@ -160,7 +160,7 @@ function transformCollectionIABChildCategory(
  */
 export const getCollectionLabelsForSnowplow = async (
   dbClient: PrismaClient,
-  collectionLabels: CollectionLabel[]
+  collectionLabels: CollectionLabel[],
 ): Promise<dbLabel[]> => {
   const labels: dbLabel[] = [];
   // collectionLabel variable here represents the collection-label connection entity
@@ -183,7 +183,7 @@ function getDateInSeconds(date: Date): number {
  */
 export function transformDbCollectionToSnowplowCollection(
   collection: CollectionComplete,
-  collectionLabels: dbLabel[]
+  collectionLabels: dbLabel[],
 ): Collection {
   const hasAuthors = collection.authors && collection.authors.length !== 0;
   const hasStories = collection.stories && collection.stories.length !== 0;
@@ -227,7 +227,7 @@ export function transformDbCollectionToSnowplowCollection(
 export async function generateEventBridgePayload(
   dbClient: PrismaClient,
   eventType: EventBridgeEventType,
-  collection: CollectionComplete
+  collection: CollectionComplete,
 ): Promise<CollectionEventBusPayload> {
   // check if collection has any labels and fetch them
   const hasLabels = collection.labels && collection.labels.length !== 0;
@@ -238,7 +238,7 @@ export async function generateEventBridgePayload(
   return {
     collection: transformDbCollectionToSnowplowCollection(
       collection,
-      collectionLabels // pass in collection labels to the main transform function
+      collectionLabels, // pass in collection labels to the main transform function
     ),
     eventType: eventType,
     object_version: 'new',
@@ -252,12 +252,12 @@ export async function generateEventBridgePayload(
 export async function sendEventBridgeEvent(
   dbClient: PrismaClient,
   eventType: EventBridgeEventType,
-  collection: CollectionComplete
+  collection: CollectionComplete,
 ) {
   const payload = await generateEventBridgePayload(
     dbClient,
     eventType,
-    collection
+    collection,
   );
 
   // Send to Event Bridge. Yay!
@@ -269,7 +269,7 @@ export async function sendEventBridgeEvent(
     const failedEventError = new Error(
       `sendEventBridgeEvent: Failed to send event '${
         payload.eventType
-      }' to event bus. Event Body:\n ${JSON.stringify(payload)}`
+      }' to event bus. Event Body:\n ${JSON.stringify(payload)}`,
     );
     // Don't halt program, but capture the failure in Sentry and Cloudwatch
     Sentry.addBreadcrumb(failedEventError);
@@ -298,14 +298,14 @@ export async function sendEvent(eventPayload: any) {
   });
 
   const output: PutEventsCommandOutput = await eventBridgeClient.send(
-    putEventCommand
+    putEventCommand,
   );
 
   if (output.FailedEntryCount) {
     const failedEventError = new Error(
       `sendEvent: Failed to send event '${
         eventPayload.eventType
-      }' to event bus. Event Body:\n ${JSON.stringify(eventPayload)}`
+      }' to event bus. Event Body:\n ${JSON.stringify(eventPayload)}`,
     );
 
     // Don't halt program, but capture the failure in Sentry and Cloudwatch

--- a/src/express.ts
+++ b/src/express.ts
@@ -12,9 +12,6 @@ import { getAdminContext, IAdminContext } from './admin/context';
 import { startPublicServer } from './public/server';
 import { startAdminServer } from './admin/server';
 import { client } from './database/client';
-import { setLogger, setMorgan } from '@pocket-tools/ts-logger';
-
-export const serverLogger = setLogger();
 
 /**
  * Initialize an express server with both public and admin graphs.
@@ -40,8 +37,7 @@ export async function startServer(port: number): Promise<{
 
   app.use(
     // JSON parser to enable POST body with JSON
-    express.json(),
-    setMorgan(serverLogger),
+    express.json()
   );
 
   // Upload middleware
@@ -49,7 +45,7 @@ export async function startServer(port: number): Promise<{
     graphqlUploadExpress({
       maxFileSize: config.app.upload.maxSize,
       maxFiles: config.app.upload.maxFiles,
-    }),
+    })
   );
 
   // expose a health check url that ensures we can access the database
@@ -73,7 +69,7 @@ export async function startServer(port: number): Promise<{
     cors<cors.CorsRequest>(),
     expressMiddleware<IAdminContext>(adminServer, {
       context: getAdminContext,
-    }),
+    })
   );
 
   // set up public server
@@ -85,7 +81,7 @@ export async function startServer(port: number): Promise<{
     cors<cors.CorsRequest>(),
     expressMiddleware<IPublicContext>(publicServer, {
       context: getPublicContext,
-    }),
+    })
   );
 
   await new Promise<void>((resolve) => httpServer.listen({ port }, resolve));

--- a/src/express.ts
+++ b/src/express.ts
@@ -37,7 +37,7 @@ export async function startServer(port: number): Promise<{
 
   app.use(
     // JSON parser to enable POST body with JSON
-    express.json()
+    express.json(),
   );
 
   // Upload middleware
@@ -45,7 +45,7 @@ export async function startServer(port: number): Promise<{
     graphqlUploadExpress({
       maxFileSize: config.app.upload.maxSize,
       maxFiles: config.app.upload.maxFiles,
-    })
+    }),
   );
 
   // expose a health check url that ensures we can access the database
@@ -69,7 +69,7 @@ export async function startServer(port: number): Promise<{
     cors<cors.CorsRequest>(),
     expressMiddleware<IAdminContext>(adminServer, {
       context: getAdminContext,
-    })
+    }),
   );
 
   // set up public server
@@ -81,7 +81,7 @@ export async function startServer(port: number): Promise<{
     cors<cors.CorsRequest>(),
     expressMiddleware<IPublicContext>(publicServer, {
       context: getPublicContext,
-    })
+    }),
   );
 
   await new Promise<void>((resolve) => httpServer.listen({ port }, resolve));

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,12 @@
-import { serverLogger, startServer } from './express';
+import { startServer } from './express';
 import config from './config';
 
 (async () => {
   const { adminUrl, publicUrl } = await startServer(config.app.port);
-  serverLogger.info(
-    `🚀 Public server ready at http://localhost:${config.app.port}${publicUrl}`,
+  console.log(
+    `🚀 Public server ready at http://localhost:${config.app.port}${publicUrl}`
   );
-  serverLogger.info(
-    `🚀 Admin server ready at http://localhost:${config.app.port}${adminUrl}`,
+  console.log(
+    `🚀 Admin server ready at http://localhost:${config.app.port}${adminUrl}`
   );
 })();

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,9 +4,9 @@ import config from './config';
 (async () => {
   const { adminUrl, publicUrl } = await startServer(config.app.port);
   console.log(
-    `🚀 Public server ready at http://localhost:${config.app.port}${publicUrl}`
+    `🚀 Public server ready at http://localhost:${config.app.port}${publicUrl}`,
   );
   console.log(
-    `🚀 Admin server ready at http://localhost:${config.app.port}${adminUrl}`
+    `🚀 Admin server ready at http://localhost:${config.app.port}${adminUrl}`,
   );
 })();

--- a/src/public/resolvers/item.ts
+++ b/src/public/resolvers/item.ts
@@ -10,7 +10,7 @@ import { getCollectionUrlSlug } from '../../utils';
 export async function collection(
   { givenUrl },
   _,
-  { dataLoaders }
+  { dataLoaders },
 ): Promise<Collection> {
   try {
     const slug = getCollectionUrlSlug(givenUrl);

--- a/src/public/resolvers/item.ts
+++ b/src/public/resolvers/item.ts
@@ -1,6 +1,5 @@
 import { Collection } from '@prisma/client';
 import * as Sentry from '@sentry/node';
-import { serverLogger } from '../../express';
 import { getCollectionUrlSlug } from '../../utils';
 
 /**
@@ -11,7 +10,7 @@ import { getCollectionUrlSlug } from '../../utils';
 export async function collection(
   { givenUrl },
   _,
-  { dataLoaders },
+  { dataLoaders }
 ): Promise<Collection> {
   try {
     const slug = getCollectionUrlSlug(givenUrl);
@@ -22,7 +21,7 @@ export async function collection(
       return null;
     }
   } catch (err) {
-    serverLogger.error(err);
+    console.log(err);
     Sentry.captureException(err);
     throw err;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,6 @@
 import { Pagination } from './typeDefs';
 import { UserInputError } from '@pocket-tools/apollo-utils';
 import { CollectionLanguage } from './database/types';
-import { serverLogger } from './express';
 
 // string of allowed languages in the format "en|de|..."
 const allowedLanguages = Object.values(CollectionLanguage).join('|');
@@ -51,7 +50,7 @@ export function collectionFilterValidation(filters: any, properties: string) {
 export function getCollectionUrlSlug(url: string): string | null {
   const match = validCollectionUrlRegExp.exec(url);
   if (!match) {
-    serverLogger.info(`${url} is not a valid collection`);
+    console.log(`${url} is not a valid collection`);
     return null;
   }
 


### PR DESCRIPTION
## Goal

in a long [slack thread](https://mozilla.slack.com/archives/C05EVRU1U1X/p1705001200188929), we have reason to believe ts-logger is causing memory leak issues - specifically on services that do not deploy (task roll-over) very often.

this PR is to check/validate that hypothesis. if this PR results in better memory metrics, we'll need to follow-up in a somewhat significant way in two aspects: meaningful, discoverable logging and updating other services using ts-logger.

## Tickets

- https://mozilla-hub.atlassian.net/browse/MC-445