### PR TITLE
perf(logging): remove logging when URL isn't a collection

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,7 +50,6 @@ export function collectionFilterValidation(filters: any, properties: string) {
 export function getCollectionUrlSlug(url: string): string | null {
   const match = validCollectionUrlRegExp.exec(url);
   if (!match) {
-    console.log(`${url} is not a valid collection`);
     return null;
   }
 


### PR DESCRIPTION
## Goal

removing a superfluous logging statement that provides no value. hoping this reduces some CPU usage (as this logging statement is hit in high volume).

## Tickets

- https://mozilla-hub.atlassian.net/browse/MC-450