### PR TITLE
perf: add compound index to Collection model for public getCollections query

### DIFF
--- a/prisma/migrations/20240119192017_add_status_language_published_at_compound_index_collections/migration.sql
+++ b/prisma/migrations/20240119192017_add_status_language_published_at_compound_index_collections/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX `Collection_status_language_publishedAt_idx` ON `Collection`(`status`, `language`, `publishedAt`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,6 +140,10 @@ model Collection {
   stories             CollectionStory[]
   authors             CollectionAuthor[]     @relation("CollectionToCollectionAuthor")
 
+  // this compound index is for the public getCollections query
+  // status and language are always present in the WHERE
+  // publishedAt is always the ORDER BY
+  @@index([status, language, publishedAt])
   @@index([slug])
   @@index([title])
   @@index([IABChildCategoryId], map: "Collection_IABChildCategoryId_fkey")


### PR DESCRIPTION
## Goal

add a compound index to increase performance on the `getCollections` public query.

[successful dev deploy](https://app.circleci.com/pipelines/github/Pocket/collection-api/6601/workflows/756026a7-8fcc-49c5-9e0a-82095add8a04).

## Tickets

- https://mozilla-hub.atlassian.net/browse/MC-501

## Implementation Decisions

see the ticket above for details, but tl;dr - the query _always_ includes a `language` and `status` filter in the `WHERE` clause, and is _always_ ordered by `publishedAt`. we've tested this migration and index on dev.
